### PR TITLE
フラッシュメッセージの表示

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,10 @@
 module ApplicationHelper
+  def flash_background_color(type)
+    case type.to_sym
+    when :notice then "bg-info-500"
+    when :alert  then "bg-error-500"
+    when :error  then "bg-warning-500"
+    else "bg-gray-500"
+    end
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,9 +1,9 @@
 module ApplicationHelper
   def flash_background_color(type)
     case type.to_sym
-    when :notice then "bg-info-500"
-    when :alert  then "bg-error-500"
-    when :error  then "bg-warning-500"
+    when :notice then "bg-[#8DBA30]"
+    when :alert  then "bg-[#f84c08]"
+    when :error  then "bg-[#f6b827]"
     else "bg-gray-500"
     end
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,6 +18,7 @@
   </head>
 
   <body class="text-neutral">
+    <%= render "shared/flash_messages" %>
     <% if user_signed_in? %>
       <%= render "shared/header" %>
     <% else %>

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -1,0 +1,5 @@
+<% flash.each do |message_type, message| %>
+  <div class="<%= flash_background_color(message_type) %> px-4 py-2 rounded-md text-white mb-4">
+    <%= message %>
+  </div>
+<% end %>

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -1,5 +1,5 @@
 <% flash.each do |message_type, message| %>
-  <div class="<%= flash_background_color(message_type) %> px-4 py-2 rounded-md text-white mb-4">
+  <div class="<%= flash_background_color(message_type) %> px-4 py-2 rounded-md text-white mb-4 mt-16">
     <%= message %>
   </div>
 <% end %>


### PR DESCRIPTION
## issue番号
close #12 

## 概要
ユーザー登録成功、失敗、ログイン成功、失敗、ログアウト時のフラッシュメッセージを設定

## 実施内容
- helperメソッドとしてメッセージの背景色を設定
- パーシャルファイルを作成
- レイアウトファイルでの読み込み

## 備考
- deviseでフラッシュオブジェクトの格納はデフォルトで実装されているため、コントローラーはカスタマイズ不要だった