### PR TITLE
エラーメッセージの表示

### DIFF
--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,5 +1,5 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation" data-turbo-cache="false">
+  <div id="error_explanation" data-turbo-cache="false", class="text-center">
     <h2>
       <%= I18n.t("errors.messages.not_saved",
                  count: resource.errors.count,

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,9 @@
+<% if object.errors.any? %>
+  <div class="alert alert-warning">
+    <ul>
+      <f object.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,9 @@
+<% if object.errors.any? %>
+  <div class="alert alert-danger text-center">
+    <ul class="mb-0">
+      <% object.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,9 +1,0 @@
-<% if object.errors.any? %>
-  <div class="alert alert-warning">
-    <ul>
-      <f object.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-    </ul>
-  </div>
-<% end %>


### PR DESCRIPTION
## issue番号
close #13 

## 概要
エラー発生時にエラーメッセージが表示されるよう実装

## 実施内容
- エラーメッセージ用パーシャルを作成
- deviseのデフォルトのエラーメッセージパーシャルを中央寄せに変更

## 備考
- ユーザー認証周りのエラーメッセージはdeviseで実装済みだった
- 今後投稿機能などのフォームを追加する際、エラーメッセージパーシャルを配置する
