### PR TITLE
ログイン、ユーザー登録完了後の遷移先を投稿一覧に変更

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -52,11 +52,11 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # The path used after sign up.
   def after_sign_up_path_for(resource)
-    super(resource)
+    posts_path
   end
 
   # The path used after sign up for inactive accounts.
   def after_inactive_sign_up_path_for(resource)
-    super(resource)
+    posts_path
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -18,10 +18,14 @@ class Users::SessionsController < Devise::SessionsController
   #   super
   # end
 
-  # protected
+  protected
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_in_params
   #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
   # end
+  # サインイン後のリダイレクト先を指定する
+  def after_sign_in_path_for(resource)
+    posts_path
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
     },
     controllers: {
       registrations: "users/registrations",
+      sessions: 'users/sessions'
   }
   resources :posts, only: %i[index new create]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html


### PR DESCRIPTION
## issue番号
close #65 

## 概要
ログイン、ユーザー登録完了後の遷移先を投稿一覧に変更

## 実施内容
- deviseのコントローラを編集し遷移先にposts_pathを指定
- deviseのルーティングにsessions_controllerを認識するよう設定

## 備考
