### PR TITLE
Dockerビルド時にImageMagickをインストールするよう追記

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ FROM base AS build
 # Install packages needed to build gems and node modules
 RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential default-libmysqlclient-dev git node-gyp pkg-config python-is-python3 && \
+    apt-get install --no-install-recommends -y imagemagick && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Install JavaScript dependencies


### PR DESCRIPTION
## issue番号
#18 

## 概要
Dockerビルド時にImageMagickをインストールするよう追記

## 実施内容
Herokuで画像投稿時にMiniMagick::Error (You must have ImageMagick or GraphicsMagick installed)のエラーが発生したため

## 備考
