### PR TITLE
本番環境用DockerfileのImageMagickインストールの文言を削除

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,6 @@ FROM base AS build
 # Install packages needed to build gems and node modules
 RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential default-libmysqlclient-dev git node-gyp pkg-config python-is-python3 && \
-    apt-get install --no-install-recommends -y imagemagick && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Install JavaScript dependencies


### PR DESCRIPTION
## issue番号
#18 

## 概要
本番環境用DockerfileのImageMagickインストールの文言を削除

## 備考
gem RMagickがインストールできず、Herokuのコンテナがビルドできない状態にあるため、上記文言を削除しログを確認する。