### PR TITLE
S3バケットのリージョン指定を削除

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -11,7 +11,6 @@ CarrierWave.configure do |config|
       provider: 'AWS',
       aws_access_key_id: Rails.application.credentials.S3_ACCESS_KEY_ID,
       aws_secret_access_key: Rails.application.credentials.S3_SECRET_ACCESS_KEY,
-      region: Rails.application.credentials.S3_REGION,
     }
   else
     config.storage :file


### PR DESCRIPTION
## issue番号
#18 

## 概要
S3バケットのリージョン指定を削除

## 実施内容
バケットのリージョンはデフォルトのus-east-1だったので、指定の記述を削除した

## 備考
