### PR TITLE
タグ機能の追加

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -11,7 +11,8 @@ class PostsController < ApplicationController
 
   def create
     @post_form = PostForm.new(post_params)
-    if @post_form.save
+    tag_list = params[:post_form][:tag_names].split(',')
+    if @post_form.save(tag_list)
       redirect_to :posts, notice: 'おやさいReportを投稿しました。'
     else
       flash.now[:alert] = "投稿できませんでした。"

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -26,6 +26,7 @@ class PostsController < ApplicationController
       :title,
       :description,
       :post_image,
+      :tag_names,
       :mode,
       :serving,
       {ingredients_name: []},

--- a/app/forms/post_form.rb
+++ b/app/forms/post_form.rb
@@ -12,6 +12,7 @@ class PostForm
   attribute :ingredients_name
   attribute :ingredients_quantity
   attribute :steps_instruction
+  attribute :tag_names
 
   validates :user_id, presence: true
   validates :title, presence: true, length: { maximum: 255 }

--- a/app/forms/post_form.rb
+++ b/app/forms/post_form.rb
@@ -36,7 +36,7 @@ class PostForm
   end
 
 
-  def save
+  def save(tag_list)
     return false if invalid?
     ActiveRecord::Base.transaction do
       post = Post.new(user_id: user_id, title: title, description: description, post_image: post_image, mode: mode)
@@ -47,6 +47,7 @@ class PostForm
         end
       end
       post.save
+      post.save_tag(tag_list)
       if post.with_recipe?
         post.create_recipe_serving(serving: serving)
         3.times do |index|

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -12,4 +12,21 @@ class Post < ApplicationRecord
   has_many :tags, through: :post_tags
 
   enum :mode, { without_recipe: 0, with_recipe: 10 }, validate: true
+
+  def save_tag(sent_tags)
+    current_tags = self.tags.pluck(:name) unless self.tags.nil?
+    old_tags = current_tags - sent_tags
+    new_tags = sent_tags - current_tags
+
+    # 古いタグを消す
+    old_tags.each do |old|
+      self.tags.delete(Tag.find_by(name: old))
+    end
+
+    # 新しいタグを保存
+    new_tags.each do |new|
+      new_post_tag = Tag.find_or_create_by(name: new)
+      self.tags << new_post_tag
+    end
+  end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -8,6 +8,8 @@ class Post < ApplicationRecord
   has_many :recipe_ingredients, dependent: :destroy
   has_many :recipe_steps, dependent: :destroy
   has_one :recipe_serving, dependent: :destroy
+  has_many :post_tags, dependent: :destroy
+  has_many :tags, through: :post_tags
 
   enum :mode, { without_recipe: 0, with_recipe: 10 }, validate: true
 end

--- a/app/models/post_tag.rb
+++ b/app/models/post_tag.rb
@@ -1,0 +1,4 @@
+class PostTag < ApplicationRecord
+  belongs_to :post
+  belongs_to :tag
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,2 @@
+class Tag < ApplicationRecord
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,2 +1,6 @@
 class Tag < ApplicationRecord
+  has_many :post_tags, dependent: :destroy
+  has_many :posts, through: :post_tags
+
+  validates :name, uniqueness: true, presence: true
 end

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -5,13 +5,16 @@
   <div class="card-body">
     <h3 class="card-title">
       <%= post.title %>
-      <div class="badge badge-secondary">NEW</div>
+      <% if post.with_recipe? %>
+        <div class="badge badge-secondary">レシピ付き</div>
+      <% end %>
     </h3>
     <p><%= post.description %></p>
     <p><%= post.user.name %></p>
     <div class="card-actions justify-end">
-      <div class="badge badge-outline">Fashion</div>
-      <div class="badge badge-outline">Products</div>
+      <% post.tags.each do |tag| %>
+        <div class="badge badge-outline"><%= tag.name %></div>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -20,6 +20,11 @@
     </div>
 
     <div class="field">
+      <%= f.label :tag_names, class:"label w-full mx-auto" %>
+      <%= f.text_field :tag_names, autofocus: true, autocomplete: ",で区切ってタグを入力", class: 'input input-bordered input-info form-control mb-6 w-full mx-auto' %>
+    </div>
+
+    <div class="field">
       <%= f.label :mode, class:"label w-full mx-auto" %>
       <%= f.select :mode, [["レシピなし", 0], ["レシピ付き", 10]], {}, {class: 'select select-bordered select-info w-full max-w-xs mb-6'} %>
     </div>

--- a/db/migrate/20241030003359_create_tags.rb
+++ b/db/migrate/20241030003359_create_tags.rb
@@ -1,0 +1,9 @@
+class CreateTags < ActiveRecord::Migration[7.2]
+  def change
+    create_table :tags do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20241030003540_create_post_tags.rb
+++ b/db/migrate/20241030003540_create_post_tags.rb
@@ -1,0 +1,11 @@
+class CreatePostTags < ActiveRecord::Migration[7.2]
+  def change
+    create_table :post_tags do |t|
+      t.references :post, null: false, foreign_key: true
+      t.references :tag, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :post_tags, [:post_id, :tag_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_24_062238) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_30_003540) do
+  create_table "post_tags", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "post_id", null: false
+    t.bigint "tag_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id", "tag_id"], name: "index_post_tags_on_post_id_and_tag_id", unique: true
+    t.index ["post_id"], name: "index_post_tags_on_post_id"
+    t.index ["tag_id"], name: "index_post_tags_on_tag_id"
+  end
+
   create_table "posts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "title", null: false
@@ -48,6 +58,12 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_24_062238) do
     t.index ["post_id"], name: "index_recipe_steps_on_post_id"
   end
 
+  create_table "tags", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -61,6 +77,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_24_062238) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "post_tags", "posts"
+  add_foreign_key "post_tags", "tags"
   add_foreign_key "posts", "users"
   add_foreign_key "recipe_ingredients", "posts"
   add_foreign_key "recipe_servings", "posts"

--- a/test/fixtures/post_tags.yml
+++ b/test/fixtures/post_tags.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  post: one
+  tag: one
+
+two:
+  post: two
+  tag: two

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+
+two:
+  name: MyString

--- a/test/models/post_tag_test.rb
+++ b/test/models/post_tag_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class PostTagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class TagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## issue番号
close #30 

## 概要
投稿にタグ付けできる機能を追加しました

## 実施内容
- Tag、PostTagモデルを生成
- Postモデルにtag保存用のメソッドを追加
- post_formのsaveメソッドでタグが保存できるよう追記
- 投稿したタグがカードで表示されるよう追記

## 備考
タグの編集、更新は投稿の編集機能作成時に行う #28 