### PR TITLE
新規投稿フォームを動的に実装

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -8,11 +8,13 @@ class PostsController < ApplicationController
   def new
     @post_form = PostForm.new
     @ingredients_form_count = [3, @post_form.ingredients_name.size].max
+    @steps_form_count = [3, @post_form.steps_instruction.size].max
   end
 
   def create
     @post_form = PostForm.new(post_params)
     @ingredients_form_count = [3, @post_form.ingredients_name.size].max
+    @steps_form_count = [3, @post_form.steps_instruction.size].max
     tag_list = params[:post_form][:tag_names].split(',')
     if @post_form.save(tag_list)
       redirect_to :posts, notice: 'おやさいReportを投稿しました。'

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -7,11 +7,12 @@ class PostsController < ApplicationController
 
   def new
     @post_form = PostForm.new
-    @ingredients_form_count = 3
+    @ingredients_form_count = [3, @post_form.ingredients_name.size].max
   end
 
   def create
     @post_form = PostForm.new(post_params)
+    @ingredients_form_count = [3, @post_form.ingredients_name.size].max
     tag_list = params[:post_form][:tag_names].split(',')
     if @post_form.save(tag_list)
       redirect_to :posts, notice: 'おやさいReportを投稿しました。'

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -7,6 +7,7 @@ class PostsController < ApplicationController
 
   def new
     @post_form = PostForm.new
+    @ingredients_form_count = 3
   end
 
   def create
@@ -19,6 +20,10 @@ class PostsController < ApplicationController
       render :new, status: :unprocessable_entity
     end
   end
+
+  # def edit
+  #   @ingredients_form_count = [3, @post_form.ingredients_name.size].max
+  # end
 
   private
 

--- a/app/forms/post_form.rb
+++ b/app/forms/post_form.rb
@@ -50,10 +50,10 @@ class PostForm
       post.save_tag(tag_list)
       if post.with_recipe?
         post.create_recipe_serving(serving: serving)
-        3.times do |index|
+        (ingredients_name.size).times do |index|
           post.recipe_ingredients.create(name: ingredients_name[index], quantity: ingredients_quantity[index])
         end
-        3.times do |index|
+        (steps_instruction.size).times do |index|
           post.recipe_steps.create(order: index+1, instruction: steps_instruction[index])
         end
       end

--- a/app/javascript/post_form.js
+++ b/app/javascript/post_form.js
@@ -97,16 +97,38 @@ const addStepButton = document.getElementById('add_step_button');
 addStepButton.addEventListener('click', function() {
   let num = stepFields.childElementCount;
   num++;
-  stepFields.innerHTML += `
-    <div class="flex items-center mb-2">
-        <div class="inline w-10 h-10 rounded-full bg-[#8DBA30] text-center leading-10">${num}</div>
-        <input name="post_form[steps_instruction][]" class="input input-bordered input-info form-control ml-1 w-full mx-auto inline" type="text">
-        <button type="button" class="btn btn-ghost delete_button">X</button>
-    </div>
-  `;
+
+  let order = createOrder(num);
+  let instructionInput = createInstructionInput();
+  let delButton = createDelButton();
+
+  let formArea = document.createElement('div');
+  formArea.setAttribute('class', 'flex items-center mb-2');
+  formArea.appendChild(order);
+  formArea.appendChild(instructionInput);
+  formArea.appendChild(delButton);
+
+  stepFields.appendChild(formArea);
+
   set_delete_btn_disabled(stepFields);
   set_add_step_btn_disabled();
 });
+// 手順番号の作成
+function createOrder(num) {
+  let order = document.createElement('div');
+  order.setAttribute('class', 'inline w-10 h-10 rounded-full bg-[#8DBA30] text-center leading-10');
+  order.innerText = num;
+  return order;
+}
+// 手順フォームの作成
+function createInstructionInput() {
+  let instructionInput = document.createElement('input');
+  instructionInput.setAttribute('type', 'text');
+  instructionInput.setAttribute('name', 'post_form[steps_instruction][]');
+  instructionInput.setAttribute('placeholder', 'もやしを1分ほどレンジにかける');
+  instructionInput.setAttribute('class', 'input input-bordered input-info form-control ml-1 w-full mx-auto inline');
+  return instructionInput;
+}
 
 // 手順フォームの削除
 stepFields.addEventListener('click', (event) => {

--- a/app/javascript/post_form.js
+++ b/app/javascript/post_form.js
@@ -16,10 +16,10 @@ addIngredientButton.addEventListener('click', function() {
     <div class="flex">
         <input name="post_form[ingredients_name][]" placeholder="材料名" class="input input-bordered input-info form-control mb-2 mr-1 w-full mx-auto basis-4/6" type="text" id="post_form_ingredients_name">
         <input name="post_form[ingredients_quantity][]" placeholder="分量" class="input input-bordered input-info form-control mb-2 w-full mx-auto basis-2/6" type="text" id="post_form_ingredients_quantity">
-        <button type="button" class="btn btn-ghost delete_ingredient_button">X</button>
+        <button type="button" class="btn btn-ghost delete_button">X</button>
     </div>
   `;
-  set_delete_btn_disabled();
+  set_delete_btn_disabled(ingredientFields);
   set_add_btn_disabled();
 });
 
@@ -30,13 +30,13 @@ ingredientFields.addEventListener('click', (event) => {
     element = element.parentNode;
     element.remove();
 }
-  set_delete_btn_disabled();
+  set_delete_btn_disabled(ingredientFields);
   set_add_btn_disabled();
 });
 
 // 削除ボタンの無効化(要素数が1つの場合のみ無効)
-function set_delete_btn_disabled() {
-  let buttons = ingredientFields.getElementsByClassName('delete_ingredient_button');
+function set_delete_btn_disabled(field) {
+  let buttons = field.getElementsByClassName('delete_button');
   if (buttons.length == 1) {
     buttons[0].disabled = true;
   }
@@ -47,13 +47,55 @@ function set_delete_btn_disabled() {
   }
 }
 
-// 追加ボタンの無効化
+// 追加ボタンの無効化(材料フィールド)
 function set_add_btn_disabled() {
-  let buttons = ingredientFields.getElementsByClassName('delete_ingredient_button');
+  let buttons = ingredientFields.getElementsByClassName('delete_button');
   if (buttons.length < 10) {
     addIngredientButton.disabled = false;
   }
   else {
     addIngredientButton.disabled = true;
+  }
+}
+
+// 手順フォーム
+const stepFields = document.getElementById('step_fields');
+
+// 手順フォームの追加
+const addStepButton = document.getElementById('add_step_button');
+addStepButton.addEventListener('click', function() {
+  let num = stepFields.childElementCount;
+  stepFields.innerHTML += `
+    <div class="flex items-center mb-2">
+        <div class="inline w-10 h-10 rounded-full bg-[#8DBA30] text-center leading-10">${num}</div>
+        <input name="post_form[steps_instruction][]" class="input input-bordered input-info form-control ml-1 w-full mx-auto inline" type="text" id="post_form_steps_instruction">
+        <button type="button" class="btn btn-ghost delete_button">X</button>
+    </div>
+  `;
+  set_delete_btn_disabled(stepFields);
+  set_add_step_btn_disabled();
+});
+
+// 手順フォームの削除
+stepFields.addEventListener('click', (event) => {
+  let element = event.target;
+  if (element instanceof HTMLButtonElement) {
+    element = element.parentNode;
+    element.remove();
+  }
+  
+
+  set_delete_btn_disabled(stepFields);
+  set_add_step_btn_disabled();
+});
+
+// 追加ボタンの無効化(手順フィールド)
+function set_add_step_btn_disabled() {
+  let buttons = stepFields.getElementsByClassName('delete_button');
+  if (buttons.length < 8) {
+    addStepButton.disabled = false;
+  }
+  else {
+    addStepButton.disabled = true;
   }
 }

--- a/app/javascript/post_form.js
+++ b/app/javascript/post_form.js
@@ -12,16 +12,47 @@ const ingredientFields = document.getElementById('ingredient_fields');
 // 材料フォームの追加
 const addIngredientButton = document.getElementById('add_ingredient_button');
 addIngredientButton.addEventListener('click', function() {
-  ingredientFields.innerHTML += `
-    <div class="flex">
-        <input name="post_form[ingredients_name][]" placeholder="材料名" class="input input-bordered input-info form-control mb-2 mr-1 w-full mx-auto basis-4/6" type="text" id="post_form_ingredients_name">
-        <input name="post_form[ingredients_quantity][]" placeholder="分量" class="input input-bordered input-info form-control mb-2 w-full mx-auto basis-2/6" type="text" id="post_form_ingredients_quantity">
-        <button type="button" class="btn btn-ghost delete_button">X</button>
-    </div>
-  `;
+  let ingredientNameInput = createIngredientNameInput();
+  let ingredientQuantityInput = createIngredientQuantityInput();
+  let delButton = createDelButton();
+
+  let formArea = document.createElement('div');
+  formArea.setAttribute('class', 'flex');
+  formArea.appendChild(ingredientNameInput);
+  formArea.appendChild(ingredientQuantityInput);
+  formArea.appendChild(delButton);
+
+  ingredientFields.appendChild(formArea);
+
   set_delete_btn_disabled(ingredientFields);
   set_add_btn_disabled();
 });
+// 材料名フォームの作成
+function createIngredientNameInput() {
+  let nameInput = document.createElement('input');
+  nameInput.setAttribute('type', 'text');
+  nameInput.setAttribute('name', 'post_form[ingredients_name][]');
+  nameInput.setAttribute('placeholder', '材料名');
+  nameInput.setAttribute('class', 'input input-bordered input-info form-control mb-2 mr-1 w-full mx-auto basis-4/6');
+  return nameInput;
+}
+// 材料の分量フォームの作成
+function createIngredientQuantityInput() {
+  let quantityInput = document.createElement('input');
+  quantityInput.setAttribute('type', 'text');
+  quantityInput.setAttribute('name', 'post_form[ingredients_quantity][]');
+  quantityInput.setAttribute('placeholder', '分量');
+  quantityInput.setAttribute('class', 'input input-bordered input-info form-control mb-2 w-full mx-auto basis-2/6');
+  return quantityInput;
+}
+// 削除ボタンの作成
+function createDelButton() {
+  let delButton = document.createElement('button');
+  delButton.setAttribute('type', 'button');
+  delButton.setAttribute('class', 'btn btn-ghost delete_button');
+  delButton.innerText = "X"
+  return delButton;
+}
 
 // 材料フォームの削除
 ingredientFields.addEventListener('click', (event) => {
@@ -69,7 +100,7 @@ addStepButton.addEventListener('click', function() {
   stepFields.innerHTML += `
     <div class="flex items-center mb-2">
         <div class="inline w-10 h-10 rounded-full bg-[#8DBA30] text-center leading-10">${num}</div>
-        <input name="post_form[steps_instruction][]" class="input input-bordered input-info form-control ml-1 w-full mx-auto inline" type="text" id="post_form_steps_instruction">
+        <input name="post_form[steps_instruction][]" class="input input-bordered input-info form-control ml-1 w-full mx-auto inline" type="text">
         <button type="button" class="btn btn-ghost delete_button">X</button>
     </div>
   `;

--- a/app/javascript/post_form.js
+++ b/app/javascript/post_form.js
@@ -5,3 +5,55 @@ mode.addEventListener('change', (event) => {
     const selectedItem = event.target.value;
     recipeFields.style.display = selectedItem === "10" ? "block" : "none";
 });
+
+// 材料フォーム
+const ingredientFields = document.getElementById('ingredient_fields');
+
+// 材料フォームの追加
+const addIngredientButton = document.getElementById('add_ingredient_button');
+addIngredientButton.addEventListener('click', function() {
+  ingredientFields.innerHTML += `
+    <div class="flex">
+        <input name="post_form[ingredients_name][]" placeholder="材料名" class="input input-bordered input-info form-control mb-2 mr-1 w-full mx-auto basis-4/6" type="text" id="post_form_ingredients_name">
+        <input name="post_form[ingredients_quantity][]" placeholder="分量" class="input input-bordered input-info form-control mb-2 w-full mx-auto basis-2/6" type="text" id="post_form_ingredients_quantity">
+        <button type="button" class="btn btn-ghost delete_ingredient_button">X</button>
+    </div>
+  `;
+  set_delete_btn_disabled();
+  set_add_btn_disabled();
+});
+
+// 材料フォームの削除
+ingredientFields.addEventListener('click', (event) => {
+  let element = event.target;
+  if (element instanceof HTMLButtonElement) {
+    element = element.parentNode;
+    element.remove();
+}
+  set_delete_btn_disabled();
+  set_add_btn_disabled();
+});
+
+// 削除ボタンの無効化(要素数が1つの場合のみ無効)
+function set_delete_btn_disabled() {
+  let buttons = ingredientFields.getElementsByClassName('delete_ingredient_button');
+  if (buttons.length == 1) {
+    buttons[0].disabled = true;
+  }
+  else {
+    for (i = 0; i < buttons.length; i++) {
+      buttons[i].disabled = false;
+    }
+  }
+}
+
+// 追加ボタンの無効化
+function set_add_btn_disabled() {
+  let buttons = ingredientFields.getElementsByClassName('delete_ingredient_button');
+  if (buttons.length < 10) {
+    addIngredientButton.disabled = false;
+  }
+  else {
+    addIngredientButton.disabled = true;
+  }
+}

--- a/app/javascript/post_form.js
+++ b/app/javascript/post_form.js
@@ -65,6 +65,7 @@ const stepFields = document.getElementById('step_fields');
 const addStepButton = document.getElementById('add_step_button');
 addStepButton.addEventListener('click', function() {
   let num = stepFields.childElementCount;
+  num++;
   stepFields.innerHTML += `
     <div class="flex items-center mb-2">
         <div class="inline w-10 h-10 rounded-full bg-[#8DBA30] text-center leading-10">${num}</div>
@@ -83,7 +84,10 @@ stepFields.addEventListener('click', (event) => {
     element = element.parentNode;
     element.remove();
   }
-  
+  let stepForms = stepFields.children;
+  for (i = 0; i < stepForms.length; i++) {
+    stepForms[i].firstElementChild.innerText = (i + 1);
+  }
 
   set_delete_btn_disabled(stepFields);
   set_add_step_btn_disabled();

--- a/app/javascript/post_form.js
+++ b/app/javascript/post_form.js
@@ -1,0 +1,7 @@
+// レシピの有無によるフォームの表示/非表示切り替え
+const mode = document.getElementById('mode');
+const recipeFields = document.getElementById('recipe_fields');
+mode.addEventListener('change', (event) => {
+    const selectedItem = event.target.value;
+    recipeFields.style.display = selectedItem === "10" ? "block" : "none";
+});

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -35,8 +35,8 @@
             <%= f.text_field :serving, class:'input input-bordered input-info form-control mb-6 inline' %><p class="inline">人分</p>
       </div>
 
+      <%= f.label :ingredients, class:"label w-full mx-auto" %>
       <div id="ingredient_fields" class="field">
-        <%= f.label :ingredients, class:"label w-full mx-auto" %>
         <% @ingredients_form_count.times do |index| %>
           <div class="flex">
               <%= f.text_field :ingredients_name, name: "post_form[ingredients_name][]", value: @post_form.ingredients_name[index], placeholder: "材料名", class:'input input-bordered input-info form-control mb-2 mr-1 w-full mx-auto basis-4/6' %>
@@ -47,8 +47,8 @@
       </div>
       <div class="text-center"><button id="add_ingredient_button"  type="button" class="btn btn-info mt-2 mb-6 mx-auto">+ 材料を追加</button></div>
 
+      <%= f.label :steps, class:"label w-full mx-auto" %>
       <div id="step_fields" class="field">
-        <%= f.label :steps, class:"label w-full mx-auto" %>
         <% @steps_form_count.times do |index| %>
           <div class="flex items-center mb-2">
               <div class="inline w-10 h-10 rounded-full bg-[#8DBA30] text-center leading-10"><%= index+1 %></div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -35,15 +35,17 @@
             <%= f.text_field :serving, class:'input input-bordered input-info form-control mb-6 inline' %><p class="inline">人分</p>
       </div>
 
-      <div class="field mb-6">
+      <div class="field">
         <%= f.label :ingredients, class:"label w-full mx-auto" %>
         <% @ingredients_form_count.times do |index| %>
           <div class="flex">
-              <%= f.text_field :ingredients_name, name: "post_form[ingredients_name][]", value: @post_form.ingredients_name[index], placeholder: "材料名", class:'input input-bordered input-info form-control mb-2 w-full mx-auto' %>
-              <%= f.text_field :ingredients_quantity, name: "post_form[ingredients_quantity][]",value: @post_form.ingredients_quantity[index], placeholder: "分量", class:'input input-bordered input-info form-control mb-2 w-full mx-auto' %>
+              <%= f.text_field :ingredients_name, name: "post_form[ingredients_name][]", value: @post_form.ingredients_name[index], placeholder: "材料名", class:'input input-bordered input-info form-control mb-2 mr-1 w-full mx-auto basis-4/6' %>
+              <%= f.text_field :ingredients_quantity, name: "post_form[ingredients_quantity][]",value: @post_form.ingredients_quantity[index], placeholder: "分量", class:'input input-bordered input-info form-control mb-2 w-full mx-auto basis-2/6' %>
+              <a class="btn btn-ghost" onclick="delete_ingredient_form();">X</a>
           </div>
         <% end %>
       </div>
+      <div class="text-center"><a class="btn btn-info mt-2 mb-6 mx-auto" onclick="add_ingredient_form();">+ 材料を追加</a></div>
 
       <div class="field">
         <%= f.label :steps, class:"label w-full mx-auto" %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -41,24 +41,27 @@
           <div class="flex">
               <%= f.text_field :ingredients_name, name: "post_form[ingredients_name][]", value: @post_form.ingredients_name[index], placeholder: "材料名", class:'input input-bordered input-info form-control mb-2 mr-1 w-full mx-auto basis-4/6' %>
               <%= f.text_field :ingredients_quantity, name: "post_form[ingredients_quantity][]",value: @post_form.ingredients_quantity[index], placeholder: "分量", class:'input input-bordered input-info form-control mb-2 w-full mx-auto basis-2/6' %>
-              <button type="button" class="btn btn-ghost delete_ingredient_button">X</button>
+              <button type="button" class="btn btn-ghost delete_button">X</button>
           </div>
         <% end %>
       </div>
       <div class="text-center"><button id="add_ingredient_button"  type="button" class="btn btn-info mt-2 mb-6 mx-auto">+ 材料を追加</button></div>
 
-      <div class="field">
+      <div id="step_fields" class="field">
         <%= f.label :steps, class:"label w-full mx-auto" %>
         <% @steps_form_count.times do |index| %>
-          <div class="flex">
-              <div class="inline w-10 h-10 rounded-full bg-[#8DBA30] text-center leading-10">1</div>
-              <%= f.text_field :steps_instruction,name: "post_form[steps_instruction][]", value: @post_form.steps_instruction[index], class:'input input-bordered input-info form-control mb-2 w-full mx-auto inline' %>
+          <div class="flex items-center mb-2">
+              <div class="inline w-10 h-10 rounded-full bg-[#8DBA30] text-center leading-10"><%= index+1 %></div>
+              <%= f.text_field :steps_instruction,name: "post_form[steps_instruction][]", value: @post_form.steps_instruction[index], class:'input input-bordered input-info form-control ml-1 w-full mx-auto inline' %>
+              <button type="button" class="btn btn-ghost delete_button">X</button>
           </div>
         <% end %>
       </div>
+      <div class="text-center"><button id="add_step_button"  type="button" class="btn btn-info mt-2 mb-6 mx-auto">+ 手順を追加</button></div>
+
     </div>
 
-    <div class="actions">
+    <div class="actions mt-16">
       <%= f.submit '登録', class: 'btn btn-info w-full mt-6 mb-6 mx-auto' %>
     </div>
   <% end %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -49,7 +49,7 @@
 
       <div class="field">
         <%= f.label :steps, class:"label w-full mx-auto" %>
-        <% 3.times do |index| %>
+        <% @steps_form_count.times do |index| %>
           <div class="flex">
               <div class="inline w-10 h-10 rounded-full bg-[#8DBA30] text-center leading-10">1</div>
               <%= f.text_field :steps_instruction,name: "post_form[steps_instruction][]", value: @post_form.steps_instruction[index], class:'input input-bordered input-info form-control mb-2 w-full mx-auto inline' %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -63,11 +63,4 @@
 
 </div>
 
-<script>
-  const mode = document.getElementById('mode');
-  const recipeFields = document.getElementById('recipe_fields');
-  mode.addEventListener('change', (event) => {
-      const selectedItem = event.target.value;
-      recipeFields.style.display = selectedItem === "10" ? "block" : "none";
-  });
-</script>
+<%= javascript_include_tag "post_form" %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -35,17 +35,17 @@
             <%= f.text_field :serving, class:'input input-bordered input-info form-control mb-6 inline' %><p class="inline">人分</p>
       </div>
 
-      <div class="field">
+      <div id="ingredient_fields" class="field">
         <%= f.label :ingredients, class:"label w-full mx-auto" %>
         <% @ingredients_form_count.times do |index| %>
           <div class="flex">
               <%= f.text_field :ingredients_name, name: "post_form[ingredients_name][]", value: @post_form.ingredients_name[index], placeholder: "材料名", class:'input input-bordered input-info form-control mb-2 mr-1 w-full mx-auto basis-4/6' %>
               <%= f.text_field :ingredients_quantity, name: "post_form[ingredients_quantity][]",value: @post_form.ingredients_quantity[index], placeholder: "分量", class:'input input-bordered input-info form-control mb-2 w-full mx-auto basis-2/6' %>
-              <a class="btn btn-ghost" onclick="delete_ingredient_form();">X</a>
+              <button type="button" class="btn btn-ghost delete_ingredient_button">X</button>
           </div>
         <% end %>
       </div>
-      <div class="text-center"><a class="btn btn-info mt-2 mb-6 mx-auto" onclick="add_ingredient_form();">+ 材料を追加</a></div>
+      <div class="text-center"><button id="add_ingredient_button"  type="button" class="btn btn-info mt-2 mb-6 mx-auto">+ 材料を追加</button></div>
 
       <div class="field">
         <%= f.label :steps, class:"label w-full mx-auto" %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -37,7 +37,7 @@
 
       <div class="field mb-6">
         <%= f.label :ingredients, class:"label w-full mx-auto" %>
-        <% 3.times do |index| %>
+        <% @ingredients_form_count.times do |index| %>
           <div class="flex">
               <%= f.text_field :ingredients_name, name: "post_form[ingredients_name][]", value: @post_form.ingredients_name[index], placeholder: "材料名", class:'input input-bordered input-info form-control mb-2 w-full mx-auto' %>
               <%= f.text_field :ingredients_quantity, name: "post_form[ingredients_quantity][]",value: @post_form.ingredients_quantity[index], placeholder: "分量", class:'input input-bordered input-info form-control mb-2 w-full mx-auto' %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -52,7 +52,7 @@
         <% @steps_form_count.times do |index| %>
           <div class="flex items-center mb-2">
               <div class="inline w-10 h-10 rounded-full bg-[#8DBA30] text-center leading-10"><%= index+1 %></div>
-              <%= f.text_field :steps_instruction,name: "post_form[steps_instruction][]", value: @post_form.steps_instruction[index], class:'input input-bordered input-info form-control ml-1 w-full mx-auto inline' %>
+              <%= f.text_field :steps_instruction,name: "post_form[steps_instruction][]", placeholder:"もやしを1分ほどレンジにかける",value: @post_form.steps_instruction[index], class:'input input-bordered input-info form-control ml-1 w-full mx-auto inline' %>
               <button type="button" class="btn btn-ghost delete_button">X</button>
           </div>
         <% end %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -26,32 +26,34 @@
 
     <div class="field">
       <%= f.label :mode, class:"label w-full mx-auto" %>
-      <%= f.select :mode, [["レシピなし", 0], ["レシピ付き", 10]], {}, {class: 'select select-bordered select-info w-full max-w-xs mb-6'} %>
+      <%= f.select :mode, [["レシピなし", 0], ["レシピ付き", 10]], {}, {id: 'mode', class: 'select select-bordered select-info w-full max-w-xs mb-6'} %>
     </div>
 
-    <div class="field">
-      <%= f.label :serving, class:"label w-full mx-auto" %>
-          <%= f.text_field :serving, class:'input input-bordered input-info form-control mb-6 inline' %><p class="inline">人分</p>
-    </div>
+    <div id="recipe_fields" style="<%= "display:none" if @post_form.mode.nil? || @post_form.mode == "0" %>">
+      <div class="field">
+        <%= f.label :serving, class:"label w-full mx-auto" %>
+            <%= f.text_field :serving, class:'input input-bordered input-info form-control mb-6 inline' %><p class="inline">人分</p>
+      </div>
 
-    <div class="field mb-6">
-      <%= f.label :ingredients, class:"label w-full mx-auto" %>
-      <% 3.times do |index| %>
-        <div class="flex">
-            <%= f.text_field :ingredients_name, name: "post_form[ingredients_name][]", value: @post_form.ingredients_name[index], placeholder: "材料名", class:'input input-bordered input-info form-control mb-2 w-full mx-auto' %>
-            <%= f.text_field :ingredients_quantity, name: "post_form[ingredients_quantity][]",value: @post_form.ingredients_quantity[index], placeholder: "分量", class:'input input-bordered input-info form-control mb-2 w-full mx-auto' %>
-        </div>
-      <% end %>
-    </div>
+      <div class="field mb-6">
+        <%= f.label :ingredients, class:"label w-full mx-auto" %>
+        <% 3.times do |index| %>
+          <div class="flex">
+              <%= f.text_field :ingredients_name, name: "post_form[ingredients_name][]", value: @post_form.ingredients_name[index], placeholder: "材料名", class:'input input-bordered input-info form-control mb-2 w-full mx-auto' %>
+              <%= f.text_field :ingredients_quantity, name: "post_form[ingredients_quantity][]",value: @post_form.ingredients_quantity[index], placeholder: "分量", class:'input input-bordered input-info form-control mb-2 w-full mx-auto' %>
+          </div>
+        <% end %>
+      </div>
 
-    <div class="field">
-      <%= f.label :steps, class:"label w-full mx-auto" %>
-      <% 3.times do |index| %>
-        <div class="flex">
-            <div class="inline w-10 h-10 rounded-full bg-[#8DBA30] text-center leading-10">1</div>
-            <%= f.text_field :steps_instruction,name: "post_form[steps_instruction][]", value: @post_form.steps_instruction[index], class:'input input-bordered input-info form-control mb-2 w-full mx-auto inline' %>
-        </div>
-      <% end %>
+      <div class="field">
+        <%= f.label :steps, class:"label w-full mx-auto" %>
+        <% 3.times do |index| %>
+          <div class="flex">
+              <div class="inline w-10 h-10 rounded-full bg-[#8DBA30] text-center leading-10">1</div>
+              <%= f.text_field :steps_instruction,name: "post_form[steps_instruction][]", value: @post_form.steps_instruction[index], class:'input input-bordered input-info form-control mb-2 w-full mx-auto inline' %>
+          </div>
+        <% end %>
+      </div>
     </div>
 
     <div class="actions">
@@ -60,3 +62,12 @@
   <% end %>
 
 </div>
+
+<script>
+  const mode = document.getElementById('mode');
+  const recipeFields = document.getElementById('recipe_fields');
+  mode.addEventListener('change', (event) => {
+      const selectedItem = event.target.value;
+      recipeFields.style.display = selectedItem === "10" ? "block" : "none";
+  });
+</script>


### PR DESCRIPTION
## issue番号
close #24 
close #25 
close #26 

## 概要
新規投稿フォームで、以下の箇所をJSにて実装した
- 「レシピの有無」のプルダウンで「レシピ付き」を選択すると、レシピ入力用フォームが表示される
- 「材料を追加」ボタンを押すと、材料入力欄が追加される
- 「手順を追加」ボタンを押すと、手順入力欄が追加される
- 削除ボタンを押すと、該当行のフォームが削除される
- 残りのフォーム数が1つの際は削除ボタンが無効になる
- 各フォームの最大個数が表示されると、フォーム追加ボタンが無効になる

## 実施内容
- 新規投稿フォームのビューの調整(追加ボタン、削除ボタン)
- JSファイルにフォームの出しわけ処理を記載

## 備考
