### PR TITLE
投稿詳細ページの作成

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -11,6 +11,10 @@ class PostsController < ApplicationController
     @steps_form_count = [3, @post_form.steps_instruction.size].max
   end
 
+  def show
+    @post = Post.find(params[:id])
+  end
+
   def create
     @post_form = PostForm.new(post_params)
     @ingredients_form_count = [3, @post_form.ingredients_name.size].max

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -20,8 +20,9 @@ class PostsController < ApplicationController
     @ingredients_form_count = [3, @post_form.ingredients_name.size].max
     @steps_form_count = [3, @post_form.steps_instruction.size].max
     tag_list = params[:post_form][:tag_names].split(',')
-    if @post_form.save(tag_list)
-      redirect_to :posts, notice: 'おやさいReportを投稿しました。'
+    post = @post_form.save(tag_list) # 保存成功時に該当の投稿詳細にリダイレクトするため、保存されたpostを取得
+    if post
+      redirect_to post_path(post), notice: 'おやさいReportを投稿しました。'
     else
       flash.now[:alert] = "投稿できませんでした。"
       render :new, status: :unprocessable_entity

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,4 +1,4 @@
-<%= link_to "#", class: "card bg-base-100 shadow-xl transition ease-in-out delay-100 hover:-translate-y-1 hover:scale-110 duration-300" do %>
+<%= link_to post_path(post), class: "card bg-base-100 shadow-xl transition ease-in-out delay-100 hover:-translate-y-1 hover:scale-110 duration-300" do %>
   <figure>
     <%= image_tag "#{post.post_image}" %>
   </figure>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -40,7 +40,7 @@
         <% @ingredients_form_count.times do |index| %>
           <div class="flex">
               <%= f.text_field :ingredients_name, name: "post_form[ingredients_name][]", value: @post_form.ingredients_name[index], placeholder: "材料名", class:'input input-bordered input-info form-control mb-2 mr-1 w-full mx-auto basis-4/6' %>
-              <%= f.text_field :ingredients_quantity, name: "post_form[ingredients_quantity][]",value: @post_form.ingredients_quantity[index], placeholder: "分量", class:'input input-bordered input-info form-control mb-2 w-full mx-auto basis-2/6' %>
+              <%= f.text_field :ingredients_quantity, name: "post_form[ingredients_quantity][]",value: @post_form.ingredients_quantity[index], placeholder: "分量", class:'input input-bordered input-info form-control mb-2 mr-1 w-full mx-auto basis-2/6' %>
               <button type="button" class="btn btn-ghost delete_button">X</button>
           </div>
         <% end %>
@@ -52,7 +52,7 @@
         <% @steps_form_count.times do |index| %>
           <div class="flex items-center mb-2">
               <div class="inline w-10 h-10 rounded-full bg-[#8DBA30] text-center leading-10"><%= index+1 %></div>
-              <%= f.text_field :steps_instruction,name: "post_form[steps_instruction][]", placeholder:"もやしを1分ほどレンジにかける",value: @post_form.steps_instruction[index], class:'input input-bordered input-info form-control ml-1 w-full mx-auto inline' %>
+              <%= f.text_field :steps_instruction,name: "post_form[steps_instruction][]", placeholder:"もやしを1分ほどレンジにかける",value: @post_form.steps_instruction[index], class:'input input-bordered input-info form-control ml-1 mr-1 w-full mx-auto inline' %>
               <button type="button" class="btn btn-ghost delete_button">X</button>
           </div>
         <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -28,6 +28,45 @@
       </div>
       <p class="text-lg"><%= @post.user.name %></p>
     </div>
+
+    <% if @post.with_recipe?%>
+      <div class="md:flex justify-between w-full mt-10">
+        <div class="md:w-5/12">
+          <p class="text-xl font-bold md:mb-8">材料 / <span class="text-base"><%= @post.recipe_serving.serving %>人分</span></p>
+          <div class="overflow-x-auto mb-10">
+            <table class="table">
+              <!-- head -->
+              <thead>
+                <tr>
+                  <th>食材</th>
+                  <th>分量</th>
+                </tr>
+              </thead>
+              <tbody>
+                <!-- row  -->
+                <% @post.recipe_ingredients.each do |ingredient|%>
+                  <tr>
+                    <td><%= ingredient.name %></td>
+                    <td><%= ingredient.quantity %></td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div class="md:w-1/2">
+          <p class="text-xl font-bold md:mb-8">作り方</p>
+          <div class="mt-4 md:mt-10">
+            <% @post.recipe_steps.each do |step|%>
+              <div class="flex items-start mb-4">
+                <div class="inline w-8 h-8 rounded-full bg-[#8DBA30] text-center leading-8 mr-1 shrink-0"><%= step.order %></div>
+                <p class=""><%= step.instruction %></p>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    <% end %>
   </div>
 
   <div class="text-center mt-20">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,0 +1,4 @@
+<div class="container">
+  <h2><%= @post.title %></h2>
+  
+</div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,4 +1,36 @@
 <div class="container">
   <h2><%= @post.title %></h2>
-  
+  <div class="max-w-2xl mx-auto">
+    <% if @post.tags.present? %>
+      <% @post.tags.each do |tag| %>
+        <div class="badge badge-outline badge-lg"><%= tag.name %></div>
+      <% end %>
+    <% end %>
+    <div class="mx-auto w-10/12 mt-4 rounded-md">
+        <%= image_tag "#{@post.post_image}", class:"rounded-2xl" %>
+    </div>
+
+    <% if @post.description.present? %>
+      <p class="mt-10 text-xl text-center break-words"><%= @post.description %></p>
+    <% end %>
+    <div class="text-right mt-10 w-8">
+      <%= link_to "#", class:"" do %>
+        <svg class="w-8 h-8 text-neutral" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+          <path d="M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8L200.7 275.5 26.8 48H172.4L272.9 180.9 389.2 48zM364.4 421.8h39.1L151.1 88h-42L364.4 421.8z"/>
+        </svg>
+      <% end %>
+    </div>
+    <div class="mt-10 flex items-center">
+      <div class="avatar mr-2">
+        <div class="w-16 rounded-full">
+          <%= image_tag "post_default.png"%>
+        </div>
+      </div>
+      <p class="text-lg"><%= @post.user.name %></p>
+    </div>
+  </div>
+
+  <div class="text-center mt-20">
+    <%= link_to "一覧に戻る",posts_path, class: "btn btn-primary" %>
+  </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
       registrations: "users/registrations",
       sessions: 'users/sessions'
   }
-  resources :posts, only: %i[index new create]
+  resources :posts, only: %i[index new create show]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
## issue番号
close #20 
close #21 

## 概要
投稿詳細ページを作成し、投稿一覧から各投稿詳細にリンクを設定した

## 実施内容
- posts/showページを作成
- レシピなしの投稿では、タイトル、タグ、画像、ユーザー名、詳細を表示
- レシピ付きの投稿では、上記に加え何人前か、材料、作り方を表示

## 備考
