### PR TITLE
おやさいReport削除機能の実装

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,6 @@
 class PostsController < ApplicationController
   before_action :authenticate_user!, except: %i[index show]
-  before_action :set_post, only: %i[edit update]
+  before_action :set_post, only: %i[edit update destroy]
 
   def index
     @posts = Post.all
@@ -48,6 +48,11 @@ class PostsController < ApplicationController
       flash.now[:alert] = "更新できませんでした。"
       render :edit, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    @post.destroy!
+    redirect_to posts_path, notice: "投稿を削除しました", status: :see_other
   end
 
   private

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -32,7 +32,7 @@
       <% if current_user&.own?(@post)%>
         <div class="mt-10 flex items-center">
           <%= link_to "編集", edit_post_path, class:"btn btn-primary text-white mr-2" %>
-          <%= link_to "削除", "#", class:"btn btn-secondary text-white" %>
+          <%= link_to '削除', post_path(@post), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか?' }, class:"btn btn-secondary text-white" %>
         </div>
       <% end %>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
       registrations: "users/registrations",
       sessions: 'users/sessions'
   }
-  resources :posts, only: %i[index new create show edit update]
+  resources :posts, only: %i[index new create show edit update destroy]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
## issue番号
close #29 

## 概要
- おやさいReport削除機能の実装
- 自分の投稿した投稿詳細でのみ削除ボタンが表示される

## 実施内容
- destroyアクションの追加
- ビューに削除ボタンの追加

## 備考
