### PR TITLE
画像投稿機能のバグ修正

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -17,3 +17,9 @@ h2 {
 .form-container {
   max-width: 800px;
 }
+.txt-limit {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2; /* 任意の行数を指定 */
+}

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -62,6 +62,7 @@ class PostsController < ApplicationController
       :title,
       :description,
       :post_image,
+      :post_image_cache,
       :tag_names,
       :mode,
       :serving,

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -3,13 +3,13 @@
     <%= image_tag "#{post.post_image}" %>
   </figure>
   <div class="card-body">
-    <h3 class="card-title">
+    <h3 class="card-title txt-limit">
       <%= post.title %>
       <% if post.with_recipe? %>
         <div class="badge badge-secondary">レシピ付き</div>
       <% end %>
     </h3>
-    <p><%= post.description %></p>
+    <p class="txt-limit"><%= post.description %></p>
     <p><%= post.user.name %></p>
     <div class="card-actions justify-end">
       <% post.tags.each do |tag| %>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -12,6 +12,8 @@
     <div class="field">
       <%= f.label :post_image, class:"label w-full mx-auto" %>
       <%= f.file_field :post_image, autocomplete: "ファイル", class: 'file-input file-input-bordered file-input-info form-control mb-6 w-full mx-auto text-neutral' %>
+      <%= f.hidden_field :post_image_cache %>
+      <%= image_tag(@post_form.post_image.url) if @post_form.post_image? %>
     </div>
 
     <div class="field">

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -12,6 +12,8 @@
     <div class="field">
       <%= f.label :post_image, class:"label w-full mx-auto" %>
       <%= f.file_field :post_image, autocomplete: "ファイル", class: 'file-input file-input-bordered file-input-info form-control mb-6 w-full mx-auto text-neutral' %>
+      <%= f.hidden_field :post_image_cache %>
+      <%= image_tag(@post_form.post_image.url) if @post_form.post_image? %>
     </div>
 
     <div class="field">


### PR DESCRIPTION
## 概要
投稿失敗時、設定した画像パスが保持されない点を修正しました

## 実施内容
- 投稿フォームで画像urlのキャッシュを取得
- 投稿失敗でrenderした際は、キャッシュされたurlと該当画像のサムネイルが表示されるよう実装

## 備考
