### PR TITLE
プロフィール編集機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,5 +73,5 @@ gem "rmagick"
 gem "fog-aws"
 
 # i18n
-gem 'rails-i18n', '~> 7.0.0'
-gem 'devise-i18n'
+gem "rails-i18n", "~> 7.0.0"
+gem "devise-i18n"

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,10 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+  def ensure_correct_user
+    @user = User.find(params[:id])
+    if !current_user || @user.id != current_user.id
+      redirect_back fallback_location: root_path, notice: t("defaults.flash_message.not_authenticated")
+    end
+  end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -23,9 +23,9 @@ class PostsController < ApplicationController
     tag_list = params[:post_form][:tag_names]&.split(",")
     post = @post_form.save(tag_list) # 保存成功時に該当の投稿詳細にリダイレクトするため、保存されたpostを取得
     if post
-      redirect_to post_path(post), notice: t('defaults.flash_message.created', item: Post.model_name.human)
+      redirect_to post_path(post), notice: t("defaults.flash_message.created", item: Post.model_name.human)
     else
-      flash.now[:alert] = t('defaults.flash_message.not_created', item: Post.model_name.human)
+      flash.now[:alert] = t("defaults.flash_message.not_created", item: Post.model_name.human)
       render :new, status: :unprocessable_entity
     end
   end
@@ -43,16 +43,16 @@ class PostsController < ApplicationController
     tag_list = params[:post_form][:tag_names]&.split(",")
     post = @post_form.update(tag_list)
     if post
-      redirect_to post_path(post), notice: t('defaults.flash_message.edited', item: Post.model_name.human)
+      redirect_to post_path(post), notice: t("defaults.flash_message.edited", item: Post.model_name.human)
     else
-      flash.now[:alert] = t('defaults.flash_message.not_edited', item: Post.model_name.human)
+      flash.now[:alert] = t("defaults.flash_message.not_edited", item: Post.model_name.human)
       render :edit, status: :unprocessable_entity
     end
   end
 
   def destroy
     @post.destroy!
-    redirect_to posts_path, notice: t('defaults.flash_message.deleted', item: Post.model_name.human), status: :see_other
+    redirect_to posts_path, notice: t("defaults.flash_message.deleted", item: Post.model_name.human), status: :see_other
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,4 +6,12 @@ class UsersController < ApplicationController
     vegetable_log = VegetableLog.find_by(user_id: @user.id, date: Time.zone.today)
     @vegetable_log = vegetable_log ? vegetable_log : VegetableLog.new
   end
+
+  def edit
+
+  end
+
+  def update
+    
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,8 @@
 class UsersController < ApplicationController
-  before_action :set_user
+  before_action :ensure_correct_user, only: %i[ edit update ]
 
   def show
+    @user = User.find(params[:id])
     vegetable_logs = VegetableLog.where(user_id: @user.id)
     @vegetable_logs = vegetable_logs.to_json(only: [ :date, :total ])
     vegetable_log = VegetableLog.find_by(user_id: @user.id, date: Time.zone.today)
@@ -20,10 +21,6 @@ class UsersController < ApplicationController
   end
 
   private
-
-  def set_user
-    @user = User.find(params[:id])
-  end
 
   def user_params
     params.require(:user).permit(:name, :avatar, :avatar_cache)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,17 +1,31 @@
 class UsersController < ApplicationController
+  before_action :set_user
+
   def show
-    @user = User.find(params[:id])
     vegetable_logs = VegetableLog.where(user_id: @user.id)
     @vegetable_logs = vegetable_logs.to_json(only: [ :date, :total ])
     vegetable_log = VegetableLog.find_by(user_id: @user.id, date: Time.zone.today)
     @vegetable_log = vegetable_log ? vegetable_log : VegetableLog.new
   end
 
-  def edit
-
-  end
+  def edit; end
 
   def update
-    
+    if @user.update(user_params)
+      redirect_to user_path(@user), notice: t("defaults.flash_message.created", item: User.model_name.human)
+    else
+      flash.now[:alert] = t("defaults.flash_message.not_created", item: User.model_name.human)
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_user
+    @user = User.find(params[:id])
+  end
+
+  def user_params
+    params.require(:user).permit(:name, :avatar, :avatar_cache)
   end
 end

--- a/app/controllers/vegetable_logs_controller.rb
+++ b/app/controllers/vegetable_logs_controller.rb
@@ -3,18 +3,18 @@ class VegetableLogsController < ApplicationController
     @vegetable_log = current_user.vegetable_logs.build(vegetable_log_params)
     p @vegetable_log
     if @vegetable_log.save && @vegetable_log.calculate_total
-      redirect_to user_path(current_user), notice: t('defaults.flash_message.vegetable_log.recorded', item: VegetableLog.model_name.human)
+      redirect_to user_path(current_user), notice: t("defaults.flash_message.vegetable_log.recorded", item: VegetableLog.model_name.human)
     else
-      redirect_to user_path(current_user), notice: t('defaults.flash_message.vegetable_log.not_recorded', item: VegetableLog.model_name.human), status: :unprocessable_entity
+      redirect_to user_path(current_user), notice: t("defaults.flash_message.vegetable_log.not_recorded", item: VegetableLog.model_name.human), status: :unprocessable_entity
     end
   end
 
   def update
     @vegetable_log = current_user.vegetable_logs.find(params[:id])
     if @vegetable_log.update(vegetable_log_params) && @vegetable_log.calculate_total
-      redirect_to user_path(current_user), notice: t('defaults.flash_message.vegetable_log.recorded', item: VegetableLog.model_name.human)
+      redirect_to user_path(current_user), notice: t("defaults.flash_message.vegetable_log.recorded", item: VegetableLog.model_name.human)
     else
-      redirect_to user_path(current_user), notice: t('defaults.flash_message.vegetable_log.not_recorded', item: VegetableLog.model_name.human), status: :unprocessable_entity
+      redirect_to user_path(current_user), notice: t("defaults.flash_message.vegetable_log.not_recorded", item: VegetableLog.model_name.human), status: :unprocessable_entity
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,8 @@ class User < ApplicationRecord
   has_many :posts, dependent: :destroy
   has_many :vegetable_logs, dependent: :destroy
 
+  mount_uploader :avatar, AvatarUploader
+
   def own?(object)
     id == object&.user_id
   end

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -1,0 +1,51 @@
+class AvatarUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  if Rails.env.production?
+    storage :fog
+  else
+    storage :file
+  end
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # For Rails 3.1+ asset pipeline compatibility:
+  # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  # "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  def default_url(*args)
+    "post_default.png"
+  end
+
+  # Process files as they are uploaded:
+  process resize_to_fit: [ 100, 100 ]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add an allowlist of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  def extension_allowlist
+    %w[jpg jpeg gif png]
+  end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg"
+  # end
+end
+

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,24 @@
+<div class="container form-container">
+  <h2><%= t('.title') %></h2>
+
+  <%= form_with model: @user  do |f| %>
+    <%= render "shared/error_messages", object: f.object %>
+  
+    <div class="field">
+      <%= f.label :name,User.human_attribute_name(:name), class:"label w-full mx-auto" %>
+      <%= f.text_field :name, autofocus: true, autocomplete: "名前", class: 'input input-bordered input-info form-control mb-6 w-full mx-auto' %>
+    </div>
+  
+    <div class="field">
+      <%= f.label :avatar,User.human_attribute_name(:avatar), class:"label w-full mx-auto" %>
+      <%= f.file_field :avatar, autocomplete: "ファイル", class: 'file-input file-input-bordered file-input-info form-control mb-6 w-full mx-auto text-neutral' %>
+      <%= f.hidden_field :avatar_cache %>
+      <%= image_tag(@user.avatar.url) if @user.avatar? %>
+    </div>
+
+    <div class="actions mt-16">
+      <%= f.submit '登録', class: 'btn btn-info w-full mt-6 mb-6 mx-auto' %>
+    </div>
+  <% end %>
+
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -22,6 +22,38 @@
     </div>
   </dialog>
 
+  <% # プロフィール情報 %>
+  <% if current_user && current_user.id == @user.id %>
+    <div class="flex justify-between lg:w-2/5 mx-auto">
+      <div class="mt-10 flex items-center text-lg">
+        <div class="avatar mr-2">
+          <div class="w-16 rounded-full">
+            <%= image_tag "#{@user.avatar}"%>
+          </div>
+        </div>
+        <div>
+          <%= @user.name%>
+          <p>おやさいレベル</p>
+        </div>
+      </div>
+      <div class="mt-10 flex items-center">
+        <%= link_to "編集", edit_user_path(@user), class:"btn btn-primary text-white mr-2" %>
+      </div>
+    </div>
+  <% else %>
+    <div class="mt-40 flex justify-center text-lg">
+      <div class="avatar mr-2">
+        <div class="w-16 rounded-full">
+          <%= image_tag "#{@user.avatar}"%>
+        </div>
+      </div>
+      <div>
+        <%= @user.name%>
+        <p>おやさいレベル</p>
+      </div>
+    </div>
+  <% end %>
+
   <h3 class="mt-28 mb-20">投稿したおやさいReport</h3>
   <% if @user.posts.present? %>
     <div class="mt-10 grid grid-cols-1 md:grid-cols-2 gap-8 xl:grid-cols-3 xl:gap-6 break-words">

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,10 +24,10 @@ module Myapp
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
 
-    config.time_zone = 'Asia/Tokyo'
+    config.time_zone = "Asia/Tokyo"
     config.active_record.default_timezone = :local
     # デフォルトのlocaleを日本語(:ja)にする
     config.i18n.default_locale = :ja
-    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
+    config.i18n.load_path += Dir[Rails.root.join("config", "locales", "**", "*.{rb,yml}").to_s]
   end
 end

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -7,6 +7,7 @@ ja:
       edited: "%{item}を更新しました"
       not_edited: "%{item}を更新出来ませんでした"
       deleted: "%{item}を削除しました"
+      not_authenticated: 権限がありません
       post_form:
         detected_blank: レシピ用フォームに空欄があります
         no_item: "%{item}が入力されていません"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   root "static_pages#home"
-  resources :users, only: %i[show]
+  resources :users, only: %i[show edit update]
   resources :posts, only: %i[index new create show edit update destroy]
   resources :vegetable_logs, only: %i[create update]
   devise_for :users,

--- a/db/migrate/20241121045229_add_avatar_to_users.rb
+++ b/db/migrate/20241121045229_add_avatar_to_users.rb
@@ -1,0 +1,5 @@
+class AddAvatarToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :avatar, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_11_045625) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_21_045229) do
   create_table "post_tags", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "post_id", null: false
     t.bigint "tag_id", null: false
@@ -73,6 +73,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_11_045625) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "avatar"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
## issue番号
close #32 

## 概要
ユーザーマイページで、ユーザーの名前とアバター画像を編集できるよう実装しました

## 実施内容
- users/showでユーザープロフィールを表示
- ログイン中ユーザーのページの場合は編集ボタンを表示
- 編集ページでは名前とアバターを変更可能
- URLベタ打ちでアクセスできないよう、ユーザーを確認するbefore_actionを設定

## 備考
