### PR TITLE
ブックマーク機能の実装

### DIFF
--- a/app/assets/images/bookmark_filled_neutral.svg
+++ b/app/assets/images/bookmark_filled_neutral.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#48350e"><path d="M200-120v-640q0-33 23.5-56.5T280-840h400q33 0 56.5 23.5T760-760v640L480-240 200-120Z"/></svg>

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -1,13 +1,11 @@
 class BookmarksController < ApplicationController
   def create
-    post = Post.find(params[:post_id])
-    current_user.bookmark(post)
-    redirect_to posts_path, success: t('.success')
+    @post = Post.find(params[:post_id])
+    current_user.bookmark(@post)
   end
 
   def destroy
-    post = current_user.bookmarks.find(params[:id]).post
-    current_user.unbookmark(post)
-    redirect_to posts_path, success: t('.success'), status: :see_other
+    @post = current_user.bookmarks.find(params[:id]).post
+    current_user.unbookmark(@post)
   end
 end

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -1,0 +1,13 @@
+class BookmarksController < ApplicationController
+  def create
+    post = Post.find(params[:post_id])
+    current_user.bookmark(post)
+    redirect_to posts_path, success: t('.success')
+  end
+
+  def destroy
+    post = current_user.bookmarks.find(params[:id]).post
+    current_user.unbookmark(post)
+    redirect_to posts_path, success: t('.success'), status: :see_other
+  end
+end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -55,6 +55,10 @@ class PostsController < ApplicationController
     redirect_to posts_path, notice: t("defaults.flash_message.deleted", item: Post.model_name.human), status: :see_other
   end
 
+  def bookmarks
+    @bookmark_posts = current_user.bookmark_posts.includes(:user).order(created_at: :desc)
+  end
+
   private
 
   def post_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,9 +13,9 @@ class UsersController < ApplicationController
 
   def update
     if @user.update(user_params)
-      redirect_to user_path(@user), notice: t("defaults.flash_message.created", item: User.model_name.human)
+      redirect_to user_path(@user), notice: t("defaults.flash_message.edited", item: User.model_name.human)
     else
-      flash.now[:alert] = t("defaults.flash_message.not_created", item: User.model_name.human)
+      flash.now[:alert] = t("defaults.flash_message.not_edited", item: User.model_name.human)
       render :new, status: :unprocessable_entity
     end
   end

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -1,0 +1,4 @@
+class Bookmark < ApplicationRecord
+  belongs_to :user
+  belongs_to :post
+end

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -1,4 +1,6 @@
 class Bookmark < ApplicationRecord
   belongs_to :user
   belongs_to :post
+
+  validates :user_id, uniqueness: { scope: :post_id }
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -10,6 +10,7 @@ class Post < ApplicationRecord
   has_one :recipe_serving, dependent: :destroy
   has_many :post_tags, dependent: :destroy
   has_many :tags, through: :post_tags
+  has_many :bookmarks, dependent: :destroy
 
   enum :mode, { without_recipe: 0, with_recipe: 10 }, validate: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,8 @@ class User < ApplicationRecord
 
   has_many :posts, dependent: :destroy
   has_many :vegetable_logs, dependent: :destroy
+  has_many :bookmarks, dependent: :destroy
+  has_many :bookmark_posts, through: :bookmarks, source: :post
 
   mount_uploader :avatar, AvatarUploader
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,4 +16,16 @@ class User < ApplicationRecord
   def own?(object)
     id == object&.user_id
   end
+
+  def bookmark(post)
+    bookmark_posts << post
+  end
+
+  def unbookmark(post)
+    bookmark_posts.destroy(post)
+  end
+
+  def bookmark?(post)
+    bookmark_posts.include?(post)
+  end
 end

--- a/app/views/bookmarks/create.turbo_stream.erb
+++ b/app/views/bookmarks/create.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "bookmark-button-for-post-#{@post.id}" do %>
+  <%= render 'posts/unbookmark', post: @post %>
+<% end %>

--- a/app/views/bookmarks/destroy.turbo_stream.erb
+++ b/app/views/bookmarks/destroy.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "unbookmark-button-for-post-#{@post.id}" do %>
+  <%= render 'posts/bookmark', post: @post %>
+<% end %>

--- a/app/views/posts/_bookmark.html.erb
+++ b/app/views/posts/_bookmark.html.erb
@@ -1,0 +1,3 @@
+<%= link_to bookmarks_path(post_id: post.id), id: "bookmark-button-for-post-#{post.id}", data: { turbo_method: :post } do %>
+  <%= image_tag 'bookmark_neutral.svg', class: 'h-10 w-10 mr-2' %>
+<% end %>

--- a/app/views/posts/_bookmark_buttons.html.erb
+++ b/app/views/posts/_bookmark_buttons.html.erb
@@ -1,0 +1,7 @@
+<div class='ms-auto'>
+  <% if current_user.bookmark?(post) %>
+    <%= render 'unbookmark', { post: post } %>
+  <% else %>
+    <%= render 'bookmark', { post: post } %>
+  <% end %>
+</div>

--- a/app/views/posts/_unbookmark.html.erb
+++ b/app/views/posts/_unbookmark.html.erb
@@ -1,0 +1,3 @@
+<%= link_to bookmark_path(current_user.bookmarks.find_by(post_id: post.id)), id: "unbookmark-button-for-post-#{post.id}", data: { turbo_method: :delete } do %>
+  <%= image_tag 'bookmark_filled_neutral.svg', class: 'h-10 w-10 mr-2' %>
+<% end %>

--- a/app/views/posts/bookmarks.html.erb
+++ b/app/views/posts/bookmarks.html.erb
@@ -1,0 +1,10 @@
+<div class="container">
+  <h2><%= t('.title') %></h2>
+  <% if @bookmark_posts.present? %>
+    <div class="mt-10 grid grid-cols-1 md:grid-cols-2 gap-8 xl:grid-cols-3 xl:gap-6 break-words">
+      <%= render @bookmark_posts %>
+    </div>
+  <% else %>
+    <p class="text-center"><%= t('.no_result') %></p>
+  <% end %>
+</div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -34,6 +34,8 @@
           <%= link_to "編集", edit_post_path, class:"btn btn-primary text-white mr-2" %>
           <%= link_to '削除', post_path(@post), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか?' }, class:"btn btn-secondary text-white" %>
         </div>
+      <% elsif current_user %>
+        <%= render "bookmark_buttons", { post: @post } %>
       <% end %>
     </div>
 

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -4,7 +4,7 @@
         <%= image_tag 'search.svg', class: "h-5 w-5 mb-1" %>
     <% end %>
 
-    <%= link_to "#", class: "flex flex-col items-center flex-1 py-1" do %>
+    <%= link_to bookmarks_posts_path, class: "flex flex-col items-center flex-1 py-1" do %>
         <%= image_tag 'bookmark_white.svg', class: "h-5 w-5 mb-1" %>
     <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,10 @@
 Rails.application.routes.draw do
   root "static_pages#home"
   resources :users, only: %i[show edit update]
-  resources :posts, only: %i[index new create show edit update destroy]
+  resources :posts, only: %i[index new create show edit update destroy] do
+    get "bookmarks", on: :collection
+  end
+  resources :bookmarks, only: %i[create destroy]
   resources :vegetable_logs, only: %i[create update]
   devise_for :users,
     path: "",

--- a/db/migrate/20241121130753_create_bookmarks.rb
+++ b/db/migrate/20241121130753_create_bookmarks.rb
@@ -1,0 +1,11 @@
+class CreateBookmarks < ActiveRecord::Migration[7.2]
+  def change
+    create_table :bookmarks do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :post, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :bookmarks, [:user_id, :post_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_21_045229) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_21_130753) do
+  create_table "bookmarks", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "post_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_bookmarks_on_post_id"
+    t.index ["user_id", "post_id"], name: "index_bookmarks_on_user_id_and_post_id", unique: true
+    t.index ["user_id"], name: "index_bookmarks_on_user_id"
+  end
+
   create_table "post_tags", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "post_id", null: false
     t.bigint "tag_id", null: false
@@ -90,6 +100,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_21_045229) do
     t.index ["user_id"], name: "index_vegetable_logs_on_user_id"
   end
 
+  add_foreign_key "bookmarks", "posts"
+  add_foreign_key "bookmarks", "users"
   add_foreign_key "post_tags", "posts"
   add_foreign_key "post_tags", "tags"
   add_foreign_key "posts", "users"

--- a/test/fixtures/bookmarks.yml
+++ b/test/fixtures/bookmarks.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  post: one
+
+two:
+  user: two
+  post: two

--- a/test/models/bookmark_test.rb
+++ b/test/models/bookmark_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class BookmarkTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## issue番号
close #45 

## 概要
投稿詳細画面で、ログイン済みかつ自分の投稿以外の場合、ブックマークボタンを表示するよう実装しました。
ブックマークした投稿は、ボトムナビゲーションまたはヘッダーメニューの「ブックマーク一覧」から参照できます。

## 実施内容
- Bookmarkモデルを作成、Userモデル、Postモデルと関連付けを設定
- posts/showにて、ログイン済みかつ他ユーザーの投稿の場合はブックマークボタンを表示
- ブックマークボタンを押すと、turbo_streamにより非同期でブックマーク済みボタンに変化するよう実装
- ブックマーク一覧画面の追加、リンクの設定

## 備考
マイページでのブックマーク一覧表示は、本リリース後に実装を検討する