### PR TITLE
おやさいReport投稿フォームのタグにおすすめタグを表示

### DIFF
--- a/app/javascript/post_form.js
+++ b/app/javascript/post_form.js
@@ -156,3 +156,22 @@ function set_add_step_btn_disabled() {
     addStepButton.disabled = true;
   }
 }
+
+// タグ入力サポートボタン
+const tagInput = document.querySelector('input[name="post_form[tag_names]"]');
+
+// タグをクリックした時の処理
+const tagLinks = document.querySelectorAll('.tag-link');
+tagLinks.forEach(link => {
+  link.addEventListener('click', (e) => {
+    // リンクのデフォルト動作を無効化
+    e.preventDefault();
+    // テキストボックスの内容にタグを追加
+    const clickedTag = e.target.innerText.trim();
+    if (tagInput.value) {
+      tagInput.value = `${tagInput.value},${clickedTag}`;
+    } else {
+      tagInput.value = `${clickedTag}`;
+    }
+  });
+});

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -15,6 +15,7 @@ class Post < ApplicationRecord
   enum :mode, { without_recipe: 0, with_recipe: 10 }, validate: true
 
   def save_tag(sent_tags)
+    sent_tags.uniq!
     current_tags = self.tags.pluck(:name) unless self.tags.nil?
     old_tags = current_tags - sent_tags
     new_tags = sent_tags - current_tags

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,6 +18,16 @@
     <script src="https://d3js.org/d3.v7.min.js"></script>
     <script src="https://unpkg.com/cal-heatmap/dist/cal-heatmap.min.js"></script>
     <link rel="stylesheet" href="https://unpkg.com/cal-heatmap/dist/cal-heatmap.css">
+
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-CSCZSL7EW0"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-CSCZSL7EW0');
+    </script>
   </head>
 
   <body class="text-neutral">

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -20,7 +20,15 @@
 
   <div class="field">
     <%= f.label :tag_names,Tag.model_name.human, class:"label w-full mx-auto" %>
-    <%= f.text_field :tag_names, autofocus: true, autocomplete: ",で区切ってタグを入力", class: 'input input-bordered input-info form-control mb-6 w-full mx-auto' %>
+    <%= f.text_field :tag_names, autofocus: true, autocomplete: ",で区切って入力してください", class: 'input input-bordered input-info form-control mb-2 w-full mx-auto' %>
+    <div class="flex justify-center flex-wrap mb-6">
+      <%= link_to 'コンビニ', '#', class: 'tag-link badge badge-ghost badge-lg mr-4 mt-4 mb-3' %>
+      <%= link_to 'スーパー', '#', class: 'tag-link badge badge-ghost badge-lg mr-4 mt-4 mb-3' %>
+      <%= link_to '外食', '#', class: 'tag-link badge badge-ghost badge-lg mr-4 mt-4 mb-3' %>
+      <%= link_to '自炊', '#', class: 'tag-link badge badge-ghost badge-lg mr-4 mt-4 mb-3' %>
+      <%= link_to 'デリバリー', '#', class: 'tag-link badge badge-ghost badge-lg mr-4 mt-4 mb-3' %>
+      <%= link_to '包丁・まな板不要', '#', class: 'tag-link badge badge-ghost badge-lg mr-4 mt-4 mb-3' %>
+    </div>
   </div>
 
   <div class="field">


### PR DESCRIPTION
## issue番号
close #109 

## 概要
投稿フォームのタグ入力欄下部に、６個のおすすめタグボタンを表示し簡単に入力できるよう実装しました。

## 実施内容
- 投稿フォームのビューにおすすめタグのボタンを設置
- ボタンを押した際の挙動をJSファイルに追加

## 備考
- 同じタグを重複入力した際、エラーが発生していたため、タグ保存用のsave_tagメソッドを修正しました