### PR TITLE
下書き機能の実装

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -25,7 +25,7 @@ class PostsController < ApplicationController
     post = @post_form.save(tag_list) # 保存成功時に該当の投稿詳細にリダイレクトするため、保存されたpostを取得
     if post
       if post.draft?
-        redirect_to post_path(post), notice: t("defaults.flash_message.created", item: defaults.draft)
+        redirect_to post_path(post), notice: t("defaults.flash_message.created", item: "下書き")
       else
         redirect_to post_path(post), notice: t("defaults.flash_message.created", item: Post.model_name.human)
       end
@@ -48,7 +48,11 @@ class PostsController < ApplicationController
     tag_list = params[:post_form][:tag_names]&.split(",")
     post = @post_form.update(tag_list)
     if post
-      redirect_to post_path(post), notice: t("defaults.flash_message.edited", item: Post.model_name.human)
+      if post.draft?
+        redirect_to post_path(post), notice: t("defaults.flash_message.edited", item: "下書き")
+      else
+        redirect_to post_path(post), notice: t("defaults.flash_message.edited", item: Post.model_name.human)
+      end
     else
       flash.now[:alert] = t("defaults.flash_message.not_edited", item: Post.model_name.human)
       render :edit, status: :unprocessable_entity
@@ -75,7 +79,7 @@ class PostsController < ApplicationController
       :post_image_cache,
       :tag_names,
       :mode,
-      :draft,
+      :status,
       :serving,
       { ingredients_name: [] },
       { ingredients_quantity: [] },

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -19,6 +19,7 @@ class PostsController < ApplicationController
 
   def create
     @post_form = PostForm.new(post_params)
+    @post_form.status = params[:draft] ? 1 : 0
     @ingredients_form_count = @post_form.ingredients_name ? @post_form.ingredients_name.size : 0
     @steps_form_count = @post_form.steps_instruction ? @post_form.steps_instruction.size : 0
     tag_list = params[:post_form][:tag_names]&.split(",")
@@ -43,15 +44,16 @@ class PostsController < ApplicationController
 
   def update
     @post_form = PostForm.new(post_params, post: @post)
+    @post_form.status = params[:draft] ? 1 : 0
     @ingredients_form_count = @post_form.ingredients_name ? @post_form.ingredients_name.size : 0
     @steps_form_count = @post_form.steps_instruction ? @post_form.steps_instruction.size : 0
     tag_list = params[:post_form][:tag_names]&.split(",")
     post = @post_form.update(tag_list)
     if post
       if post.draft?
-        redirect_to post_path(post), notice: t("defaults.flash_message.edited", item: "下書き")
+        redirect_to post_path(post), notice: t("defaults.flash_message.draft_edited")
       else
-        redirect_to post_path(post), notice: t("defaults.flash_message.edited", item: Post.model_name.human)
+        redirect_to post_path(post), notice: t("defaults.flash_message.publish_edited", item: Post.model_name.human)
       end
     else
       flash.now[:alert] = t("defaults.flash_message.not_edited", item: Post.model_name.human)
@@ -79,7 +81,6 @@ class PostsController < ApplicationController
       :post_image_cache,
       :tag_names,
       :mode,
-      :status,
       :serving,
       { ingredients_name: [] },
       { ingredients_quantity: [] },

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -15,6 +15,11 @@ class PostsController < ApplicationController
 
   def show
     @post = Post.find(params[:id])
+    if @post.draft?
+      if !current_user || @post.user_id != current_user.id
+        redirect_back fallback_location: root_path, notice: t("defaults.flash_message.not_authenticated")
+      end
+    end
   end
 
   def create
@@ -96,6 +101,10 @@ class PostsController < ApplicationController
   end
 
   def set_post
-    @post = current_user.posts.find(params[:id])
+    begin
+      @post = current_user.posts.find(params[:id])
+    rescue
+      redirect_back fallback_location: root_path, notice: t("defaults.flash_message.not_authenticated")
+    end
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -71,6 +71,11 @@ class PostsController < ApplicationController
     @bookmark_posts = @q.result(distinct: true).includes(:user).order(created_at: :desc).page(params[:page])
   end
 
+  def drafts
+    @q = current_user.posts.draft.ransack(params[:q])
+    @draft_posts = @q.result(distinct: true).includes(:user).order(created_at: :desc).page(params[:page])
+  end
+
   private
 
   def post_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,6 +21,11 @@ class UsersController < ApplicationController
     end
   end
 
+  def drafts
+    @q = current_user.bookmark_posts.ransack(params[:q])
+    @draft_posts = @q.result(distinct: true).draft.includes(:user).order(created_at: :desc).page(params[:page])
+  end
+
   private
 
   def user_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,11 +21,6 @@ class UsersController < ApplicationController
     end
   end
 
-  def drafts
-    @q = current_user.bookmark_posts.ransack(params[:q])
-    @draft_posts = @q.result(distinct: true).draft.includes(:user).order(created_at: :desc).page(params[:page])
-  end
-
   private
 
   def user_params

--- a/app/forms/post_form.rb
+++ b/app/forms/post_form.rb
@@ -8,6 +8,8 @@ class PostForm
   attribute :description, :string
   attribute :post_image, :string
   attribute :mode, :integer
+  attribute :status, :integer
+  attribute :draft, :integer
   attribute :serving, :integer
   attribute :ingredients_name
   attribute :ingredients_quantity
@@ -43,7 +45,8 @@ class PostForm
   def save(tag_list)
     return false if invalid?
     ActiveRecord::Base.transaction do
-      post = Post.create!(user_id: user_id, title: title, description: description, post_image: post_image, mode: mode)
+      status = draft.nil? ? 0 : 1
+      post = Post.create!(user_id: user_id, title: title, description: description, post_image: post_image, mode: mode, status: status)
       post.save_tag(tag_list)
       if post.with_recipe?
         post.create_recipe_serving(serving: serving)
@@ -66,7 +69,7 @@ class PostForm
   def update(tag_list)
     return false if invalid?
     ActiveRecord::Base.transaction do
-      @post.update!(user_id: user_id, title: title, description: description, post_image: post_image, mode: mode)
+      @post.update!(user_id: user_id, title: title, description: description, post_image: post_image, mode: mode, status: status)
       @post.save_tag(tag_list)
       if @post.with_recipe?
         @post.create_recipe_serving(serving: serving)
@@ -100,6 +103,8 @@ class PostForm
       post_image: post.post_image,
       tag_names: post.tags&.map(&:name)&.join(","),
       mode: post.mode_before_type_cast,
+      status: post.status_before_type_cast,
+      draft: post.status_before_type_cast,
       serving: post.recipe_serving&.serving,
       ingredients_name: post.recipe_ingredients&.map(&:name),
       ingredients_quantity: post.recipe_ingredients&.map(&:quantity),
@@ -108,7 +113,7 @@ class PostForm
   end
 
   def with_recipe?
-    return true if mode == 10
+    return true if mode == 10 && status == 0
     false
   end
 

--- a/app/forms/post_form.rb
+++ b/app/forms/post_form.rb
@@ -42,7 +42,6 @@ class PostForm
 
 
   def save(tag_list)
-    self.status = status == "公開する" ? 0 : 1
     return false if invalid?
     ActiveRecord::Base.transaction do
       post = Post.create!(user_id: user_id, title: title, description: description, post_image: post_image, mode: mode, status: status)
@@ -66,7 +65,6 @@ class PostForm
   end
 
   def update(tag_list)
-    self.status = status == "公開する" ? 0 : 1
     return false if invalid?
     ActiveRecord::Base.transaction do
       @post.update!(user_id: user_id, title: title, description: description, post_image: post_image, mode: mode, status: status)

--- a/app/forms/post_form.rb
+++ b/app/forms/post_form.rb
@@ -42,9 +42,9 @@ class PostForm
 
 
   def save(tag_list)
+    self.status = status == "公開する" ? 0 : 1
     return false if invalid?
     ActiveRecord::Base.transaction do
-      status = status == "公開する" ? 0 : 1
       post = Post.create!(user_id: user_id, title: title, description: description, post_image: post_image, mode: mode, status: status)
       post.save_tag(tag_list)
       if post.with_recipe?
@@ -66,9 +66,9 @@ class PostForm
   end
 
   def update(tag_list)
+    self.status = status == "公開する" ? 0 : 1
     return false if invalid?
     ActiveRecord::Base.transaction do
-      status = status == "公開する" ? 0 : 1
       @post.update!(user_id: user_id, title: title, description: description, post_image: post_image, mode: mode, status: status)
       @post.save_tag(tag_list)
       if @post.with_recipe?

--- a/app/forms/post_form.rb
+++ b/app/forms/post_form.rb
@@ -9,7 +9,6 @@ class PostForm
   attribute :post_image, :string
   attribute :mode, :integer
   attribute :status, :integer
-  attribute :draft, :integer
   attribute :serving, :integer
   attribute :ingredients_name
   attribute :ingredients_quantity
@@ -45,7 +44,7 @@ class PostForm
   def save(tag_list)
     return false if invalid?
     ActiveRecord::Base.transaction do
-      status = draft.nil? ? 0 : 1
+      status = status == "公開する" ? 0 : 1
       post = Post.create!(user_id: user_id, title: title, description: description, post_image: post_image, mode: mode, status: status)
       post.save_tag(tag_list)
       if post.with_recipe?
@@ -69,6 +68,7 @@ class PostForm
   def update(tag_list)
     return false if invalid?
     ActiveRecord::Base.transaction do
+      status = status == "公開する" ? 0 : 1
       @post.update!(user_id: user_id, title: title, description: description, post_image: post_image, mode: mode, status: status)
       @post.save_tag(tag_list)
       if @post.with_recipe?
@@ -104,7 +104,6 @@ class PostForm
       tag_names: post.tags&.map(&:name)&.join(","),
       mode: post.mode_before_type_cast,
       status: post.status_before_type_cast,
-      draft: post.status_before_type_cast,
       serving: post.recipe_serving&.serving,
       ingredients_name: post.recipe_ingredients&.map(&:name),
       ingredients_quantity: post.recipe_ingredients&.map(&:quantity),

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -13,6 +13,7 @@ class Post < ApplicationRecord
   has_many :bookmarks, dependent: :destroy
 
   enum :mode, { without_recipe: 0, with_recipe: 10 }, validate: true
+  enum :status, { published: 0, draft: 1 }, validate: true
 
   def save_tag(sent_tags)
     sent_tags.uniq!

--- a/app/views/posts/_bookmark.html.erb
+++ b/app/views/posts/_bookmark.html.erb
@@ -1,3 +1,3 @@
 <%= link_to bookmarks_path(post_id: post.id), id: "bookmark-button-for-post-#{post.id}", data: { turbo_method: :post } do %>
-  <%= image_tag 'bookmark_neutral.svg', class: 'h-10 w-10 mr-2' %>
+  <%= image_tag 'bookmark_neutral.svg', class: 'h-10 w-10' %>
 <% end %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -69,7 +69,7 @@
   </div>
 
   <div class="md:flex justify-between mt-16">
-    <%= f.submit t("form.publish"), name: "post_form[draft]", class: 'btn btn-info w-full md:basis-9/12' %>
-    <%= f.submit t("form.draft"), name: "post_form[draft]", class: 'btn btn-primary w-full mt-4 md:basis-1/5 md:mt-0' %>
+    <%= f.submit t("form.publish"), name: "post_form[status]", class: 'btn btn-info w-full md:basis-9/12' %>
+    <%= f.submit t("form.draft"), name: "post_form[status]", class: 'btn btn-primary w-full mt-4 md:basis-1/5 md:mt-0' %>
   </div>
 <% end %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -39,7 +39,7 @@
   <div id="recipe_fields" style="<%= "display:none" if @post_form.mode.nil? || @post_form.mode == 0 %>">
     <div class="field">
       <%= f.label :serving,RecipeServing.model_name.human, class:"label w-full mx-auto" %>
-          <%= f.text_field :serving, class:'input input-bordered input-info form-control mb-6 inline' %><p class="inline">人分</p>
+          <%= f.text_field :serving, class:'input input-bordered input-info form-control mb-6 inline w-16' %><p class="inline ml-2">人前</p>
     </div>
 
     <%= f.label :ingredients,RecipeIngredient.model_name.human, class:"label w-full mx-auto" %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -68,7 +68,8 @@
 
   </div>
 
-  <div class="actions mt-16">
-    <%= f.submit '登録', class: 'btn btn-info w-full mt-6 mb-6 mx-auto' %>
+  <div class="md:flex justify-between mt-16">
+    <%= f.submit t("form.publish"), name: "post_form[draft]", class: 'btn btn-info w-full md:basis-9/12' %>
+    <%= f.submit t("form.draft"), name: "post_form[draft]", class: 'btn btn-primary w-full mt-4 md:basis-1/5 md:mt-0' %>
   </div>
 <% end %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -69,7 +69,7 @@
   </div>
 
   <div class="md:flex justify-between mt-16">
-    <%= f.submit t("form.publish"), name: "post_form[status]", class: 'btn btn-info w-full md:basis-9/12' %>
-    <%= f.submit t("form.draft"), name: "post_form[status]", class: 'btn btn-primary w-full mt-4 md:basis-1/5 md:mt-0' %>
+    <%= f.submit t("form.publish"), class: 'btn btn-info w-full md:basis-9/12' %>
+    <%= f.submit t("form.draft"), name: "draft", class: 'btn btn-primary w-full mt-4 md:basis-1/5 md:mt-0' %>
   </div>
 <% end %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -9,6 +9,9 @@
     <% if post.with_recipe? %>
       <div class="badge badge-secondary text-white">レシピ付き</div>
     <% end %>
+    <% if post.draft? %>
+      <div class="badge badge-accent text-white">下書き</div>
+    <% end %>
     <p class="txt-limit"><%= post.description %></p>
     <p><%= post.user.name %></p>
     <div class="card-actions justify-end">

--- a/app/views/posts/_unbookmark.html.erb
+++ b/app/views/posts/_unbookmark.html.erb
@@ -1,3 +1,3 @@
 <%= link_to bookmark_path(current_user.bookmarks.find_by(post_id: post.id)), id: "unbookmark-button-for-post-#{post.id}", data: { turbo_method: :delete } do %>
-  <%= image_tag 'bookmark_filled_neutral.svg', class: 'h-10 w-10 mr-2' %>
+  <%= image_tag 'bookmark_filled_neutral.svg', class: 'h-10 w-10' %>
 <% end %>

--- a/app/views/posts/bookmarks.html.erb
+++ b/app/views/posts/bookmarks.html.erb
@@ -5,6 +5,7 @@
     <div class="mt-10 grid grid-cols-1 md:grid-cols-2 gap-8 xl:grid-cols-3 xl:gap-6 break-words">
       <%= render @bookmark_posts %>
     </div>
+    <%= paginate @bookmark_posts %>
   <% else %>
     <p class="text-center"><%= t('.no_result') %></p>
   <% end %>

--- a/app/views/posts/drafts.html.erb
+++ b/app/views/posts/drafts.html.erb
@@ -5,6 +5,7 @@
     <div class="mt-10 grid grid-cols-1 md:grid-cols-2 gap-8 xl:grid-cols-3 xl:gap-6 break-words">
       <%= render @draft_posts %>
     </div>
+    <%= paginate @draft_posts %>
   <% else %>
     <p class="text-center"><%= t('.no_result') %></p>
   <% end %>

--- a/app/views/posts/drafts.html.erb
+++ b/app/views/posts/drafts.html.erb
@@ -1,0 +1,11 @@
+<div class="container">
+  <h2><%= t('.title') %></h2>
+  <%= render 'search_form', q: @q, url: drafts_posts_path %>
+  <% if @draft_posts.present? %>
+    <div class="mt-10 grid grid-cols-1 md:grid-cols-2 gap-8 xl:grid-cols-3 xl:gap-6 break-words">
+      <%= render @draft_posts %>
+    </div>
+  <% else %>
+    <p class="text-center"><%= t('.no_result') %></p>
+  <% end %>
+</div>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,5 +1,9 @@
 <div class="container form-container">
-  <h2><%= t('.title') %></h2>
+  <% if @post.draft? %>
+    <h2><%= t('.draft_title') %></h2>
+  <% else %>
+    <h2><%= t('.title') %></h2>
+  <% end %>
 
   <%= render "form", post_form: @post_form, url: post_path(@post), ingredients_form_count:@ingredients_form_count,steps_form_count:@steps_form_count %>
 

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,9 +1,12 @@
 <div class="container">
   <h2><%= @post.title %></h2>
   <div class="max-w-2xl mx-auto">
+    <% if @post.draft? %>
+      <div class="badge badge-accent md:badge-lg badge-sm text-white block mb-2">下書き</div>
+    <% end %>
     <% if @post.tags.present? %>
       <% @post.tags.each do |tag| %>
-        <div class="badge badge-outline badge-lg"><%= tag.name %></div>
+        <div class="badge badge-outline md:badge-lg badge-sm"><%= tag.name %></div>
       <% end %>
     <% end %>
     <div class="mx-auto w-10/12 mt-4 rounded-md flex justify-center">
@@ -13,15 +16,15 @@
     <% if @post.description.present? %>
       <p class="mt-10 text-xl text-center break-words"><%= @post.description %></p>
     <% end %>
-    <div class="text-right mt-10 w-8">
+    <div class="grid sm:mt-10 mt-4 justify-items-end">
       <%= link_to "#", class:"" do %>
         <svg class="w-8 h-8 text-neutral" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
           <path d="M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8L200.7 275.5 26.8 48H172.4L272.9 180.9 389.2 48zM364.4 421.8h39.1L151.1 88h-42L364.4 421.8z"/>
         </svg>
       <% end %>
     </div>
-    <div class="md:flex justify-between w-full">
-      <%= link_to user_path(@post.user), class: "mt-10 flex items-center text-lg underline underline-offset-4 hover:text-secondary hover:duration-100" do %>
+    <div class="sm:flex justify-between w-full">
+      <%= link_to user_path(@post.user), class: "sm:mt-10 mt-4 flex items-center text-lg underline underline-offset-4 hover:text-secondary hover:duration-100" do %>
         <div class="avatar mr-2">
           <div class="w-16 rounded-full">
             <%= image_tag "post_default.png"%>
@@ -30,7 +33,7 @@
         <%= @post.user.name%>
       <% end %>
       <% if current_user&.own?(@post)%>
-        <div class="mt-10 flex items-center">
+        <div class="sm:mt-10 mt-4 flex items-center">
           <%= link_to "編集", edit_post_path, class:"btn btn-primary text-white mr-2" %>
           <%= link_to '削除', post_path(@post), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか?' }, class:"btn btn-secondary text-white" %>
         </div>
@@ -80,6 +83,10 @@
   </div>
 
   <div class="text-center mt-20 mb-40">
-    <%= link_to "一覧に戻る",posts_path, class: "btn btn-primary" %>
+    <% if @post.draft? %>
+      <%= link_to "下書き一覧に戻る",drafts_posts_path, class: "btn btn-primary" %>
+    <% else %>
+      <%= link_to "一覧に戻る",posts_path, class: "btn btn-primary" %>
+    <% end %>
   </div>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -42,7 +42,7 @@
     <% if @post.with_recipe?%>
       <div class="md:flex justify-between w-full mt-10">
         <div class="md:w-5/12">
-          <p class="text-xl font-bold md:mb-8">材料 / <span class="text-base"><%= @post.recipe_serving.serving %>人分</span></p>
+          <p class="text-xl font-bold md:mb-8">材料 / <span class="text-base"><%= @post.recipe_serving&.serving %>人分</span></p>
           <div class="overflow-x-auto mb-10">
             <table class="table">
               <!-- head -->

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -83,7 +83,12 @@
     <% end %>
   </div>
 
-  <div class="text-center mt-20 mb-40">
-    <%= link_to "戻る",:back, class: "btn btn-primary text-white" %>
+  <div class="flex flex-col items-center mt-20 mb-40">
+    <%= link_to "おやさいReport一覧を見る",posts_path, class: "btn btn-primary text-white mb-4" %>
+    <% if current_user && @post.published? %>
+      <%= link_to "お気に入り一覧を見る", bookmarks_posts_path, class: "btn btn-primary text-white mb-4" %>
+    <% elsif @post.draft? %>
+      <%= link_to "下書き一覧を見る", drafts_posts_path, class: "btn btn-primary text-white"%>
+    <% end %>
   </div>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -16,15 +16,18 @@
     <% if @post.description.present? %>
       <p class="mt-10 text-xl text-center break-words"><%= @post.description %></p>
     <% end %>
-    <div class="grid sm:mt-10 mt-4 justify-items-end">
-      <%= link_to "#", class:"" do %>
+    <div class="flex flex-row-reverse sm:mt-10 mt-4 items-center">
+      <%= link_to "#", class:"ml-2" do %>
         <svg class="w-8 h-8 text-neutral" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
           <path d="M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8L200.7 275.5 26.8 48H172.4L272.9 180.9 389.2 48zM364.4 421.8h39.1L151.1 88h-42L364.4 421.8z"/>
         </svg>
       <% end %>
+      <% if current_user && !current_user.own?(@post) %>
+        <%= render "bookmark_buttons", { post: @post } %>
+      <% end %>
     </div>
-    <div class="sm:flex justify-between w-full">
-      <%= link_to user_path(@post.user), class: "sm:mt-10 mt-4 flex items-center text-lg underline underline-offset-4 hover:text-secondary hover:duration-100" do %>
+    <div class="sm:flex sm:mt-10 mt-4 justify-between items-center w-full">
+      <%= link_to user_path(@post.user), class: "flex items-center text-lg underline underline-offset-4 hover:text-secondary hover:duration-100" do %>
         <div class="avatar mr-2">
           <div class="w-16 rounded-full">
             <%= image_tag "post_default.png"%>
@@ -33,12 +36,10 @@
         <%= @post.user.name%>
       <% end %>
       <% if current_user&.own?(@post)%>
-        <div class="sm:mt-10 mt-4 flex items-center">
+        <div class="flex items-center">
           <%= link_to "編集", edit_post_path, class:"btn btn-primary text-white mr-2" %>
           <%= link_to '削除', post_path(@post), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか?' }, class:"btn btn-secondary text-white" %>
         </div>
-      <% elsif current_user %>
-        <%= render "bookmark_buttons", { post: @post } %>
       <% end %>
     </div>
 
@@ -83,10 +84,6 @@
   </div>
 
   <div class="text-center mt-20 mb-40">
-    <% if @post.draft? %>
-      <%= link_to "下書き一覧に戻る",drafts_posts_path, class: "btn btn-primary" %>
-    <% else %>
-      <%= link_to "一覧に戻る",posts_path, class: "btn btn-primary" %>
-    <% end %>
+    <%= link_to "戻る",:back, class: "btn btn-primary text-white" %>
   </div>
 </div>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,5 +1,5 @@
 <% if object.errors.any? %>
-  <div class="alert alert-danger text-center bg-[#f6b827] text-white">
+  <div class="alert alert-danger bg-[#f6b827] text-white">
     <ul class="mb-0">
       <% object.errors.full_messages.each do |msg| %>
         <li><%= msg %></li>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -13,7 +13,7 @@
         <span class="text-[0.5rem] btm-nav-label"><%= t('footer.post_new') %></span>
     <% end %>
 
-    <%= link_to "#", class: "flex flex-col items-center flex-1 py-1" do %>
+    <%= link_to drafts_posts_path, class: "flex flex-col items-center flex-1 py-1" do %>
         <%= image_tag 'draft.svg', class: "h-5 w-5 mb-1" %>
     <% end %>
     

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,10 +2,12 @@
 
     <%= link_to posts_path, class: "flex flex-col items-center flex-1 py-1" do %>
         <%= image_tag 'search.svg', class: "h-5 w-5 mb-1" %>
+        <span class="text-[0.5rem] btm-nav-label"><%= t('footer.post_index') %></span>
     <% end %>
 
     <%= link_to bookmarks_posts_path, class: "flex flex-col items-center flex-1 py-1" do %>
         <%= image_tag 'bookmark_white.svg', class: "h-5 w-5 mb-1" %>
+        <span class="text-[0.5rem] btm-nav-label"><%= t('footer.bookmarks') %></span>
     <% end %>
 
     <%= link_to new_post_path, class: "flex flex-col items-center flex-1 py-1" do %>
@@ -15,15 +17,18 @@
 
     <%= link_to drafts_posts_path, class: "flex flex-col items-center flex-1 py-1" do %>
         <%= image_tag 'draft.svg', class: "h-5 w-5 mb-1" %>
+        <span class="text-[0.5rem] btm-nav-label"><%= t('footer.drafts') %></span>
     <% end %>
     
     <% if current_user %>
       <%= link_to user_path(current_user), class: "flex flex-col items-center flex-1 py-1" do %>
           <%= image_tag 'person.svg', class: "h-5 w-5 mb-1" %>
+          <span class="text-[0.5rem] btm-nav-label"><%= t('footer.mypage') %></span>
       <% end %>
     <% else %>
       <%= link_to new_user_session_path, class: "flex flex-col items-center flex-1 py-1" do %>
         <%= image_tag 'person.svg', class: "h-5 w-5 mb-1" %>
+        <span class="text-[0.5rem] btm-nav-label"><%= t('footer.login') %></span>
       <% end %>
     <% end %>
 

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -52,7 +52,7 @@
                         <% end %>
                     </li>
                     <li>
-                        <%= link_to "#", data: { turbo: false }, class: "text-base hover:text-secondary" do %>
+                        <%= link_to bookmarks_posts_path, data: { turbo: false }, class: "text-base hover:text-secondary" do %>
                             <%= image_tag 'bookmark_neutral.svg', class: 'h-4 w-4 mr-2' %>
                             <%= t('header.bookmark_index') %>
                         <% end %>
@@ -64,7 +64,7 @@
                         <% end %>
                     </li>
                     <li>
-                        <%= link_to "#", data: { turbo: false }, class: "text-base hover:text-secondary" do %>
+                        <%= link_to drafts_posts_path, data: { turbo: false }, class: "text-base hover:text-secondary" do %>
                             <%= image_tag 'note_neutral.svg', class: 'h-4 w-4 mr-2' %>
                             <%= t('header.draft_index') %>
                         <% end %>

--- a/config/locales/activemodel/ja.yml
+++ b/config/locales/activemodel/ja.yml
@@ -3,3 +3,4 @@ ja:
     attributes:
       post_form:
         title: タイトル
+        serving: 何人前か

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -47,3 +47,6 @@ ja:
       mode:
         without_recipe: レシピなし
         with_recipe: レシピあり
+      status:
+        published: 公開済み
+        draft: 下書き

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -6,6 +6,8 @@ ja:
       created: "%{item}を作成しました"
       not_created: "%{item}を作成出来ませんでした"
       edited: "%{item}を更新しました"
+      draft_edited: 下書きに保存しました
+      publish_edited: "%{item}を更新し公開しました"
       not_edited: "%{item}を更新出来ませんでした"
       deleted: "%{item}を削除しました"
       not_authenticated: 権限がありません

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -58,7 +58,13 @@ ja:
       title: おやさいReport編集
     bookmarks:
       title: ブックマーク一覧
-      no_result: ブックマーク中のおやさいReportがありません。
+      no_result: ブックマーク中のおやさいReportはありません
+    drafts:
+      title: 下書き一覧
+      no_result: おやさいReportの下書きはありません
+    users:
+      edit:
+        title: プロフィール編集
   bookmarks:
     create:
       success: ブックマークしました

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -52,6 +52,7 @@ ja:
     index:
       title: おやさいReport一覧
     edit:
+      draft_title: 下書き編集
       title: おやさいReport編集
     bookmarks:
       title: ブックマーク一覧
@@ -82,3 +83,6 @@ ja:
   search:
     placeholder: タイトル・本文
     blank: レシピの有無
+  form:
+    publish: 公開する
+    draft: 下書き保存

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -46,6 +46,11 @@ ja:
     draft_index: 下書き一覧
   footer:
     post_new: Reportを書く
+    post_index: Report一覧
+    bookmarks: ブックマーク
+    drafts: 下書き
+    mypage: マイページ
+    login: ログイン
   posts:
     new:
       title: おやさいReport作成

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,6 +1,7 @@
 ja:
   defaults:
     post: 投稿
+    draft: 下書き
     flash_message:
       created: "%{item}を作成しました"
       not_created: "%{item}を作成出来ませんでした"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   root "static_pages#home"
-  resources :users, only: %i[show edit update]
+  resources :users, only: %i[show edit update] do
+    get "drafts", on: :member
+  end
   resources :posts, only: %i[index new create show edit update destroy] do
     get "bookmarks", on: :collection
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,9 @@
 Rails.application.routes.draw do
   root "static_pages#home"
-  resources :users, only: %i[show edit update] do
-    get "drafts", on: :member
-  end
+  resources :users, only: %i[show edit update]
   resources :posts, only: %i[index new create show edit update destroy] do
     get "bookmarks", on: :collection
+    get "drafts", on: :collection
   end
   resources :bookmarks, only: %i[create destroy]
   resources :vegetable_logs, only: %i[create update]

--- a/db/migrate/20241127012834_add_status_to_posts.rb
+++ b/db/migrate/20241127012834_add_status_to_posts.rb
@@ -1,0 +1,5 @@
+class AddStatusToPosts < ActiveRecord::Migration[7.2]
+  def change
+    add_column :posts, :status, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_21_130753) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_27_012834) do
   create_table "bookmarks", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "post_id", null: false
@@ -39,6 +39,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_21_130753) do
     t.datetime "updated_at", null: false
     t.string "post_image"
     t.integer "mode", default: 0, null: false
+    t.integer "status", default: 0, null: false
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 


### PR DESCRIPTION
## issue番号
close #42 
close #43 

## 概要
おやさいReportを下書き保存できる機能を実装しました
- 投稿新規作成ページ、編集ページにて、「公開する」「下書き保存」の2種類のボタンを設置しました
- 下書き保存のボタンを押すと、レシピ部分が空欄でも保存が実行されます
- 下書きはフッター、ヘッダーナビゲーションの「下書き一覧」リンクから閲覧できます
- 投稿したユーザーは、Report編集ページから公開/下書きの状態を変更できます

## 実施内容
- Postモデルに、投稿の公開状態を管理するstatusカラムを追加、enumを設定
- postsコントローラー、post_formに下書き保存の際の処理を追加
- フッター、ヘッダーに下書き一覧へのリンクを追加

## 備考
- 新規投稿、編集ページでは削除ボタンを設置せず、投稿詳細ページからのみ削除可能としました
- ユーザーのマイページでの下書き一覧表示タブを設置するかどうかは、別途検討することとしました