### PR TITLE
ユーザーのレベルアップ機能を追加

### DIFF
--- a/app/controllers/ai_recipes_controller.rb
+++ b/app/controllers/ai_recipes_controller.rb
@@ -6,16 +6,16 @@ class AiRecipesController < ApplicationController
   before_action :check_csrf
 
   def create
-    former_ingredient_name, new_ingredient_name = params[:former_ingredient_name],params[:new_ingredient_name]
+    former_ingredient_name, new_ingredient_name = params[:former_ingredient_name], params[:new_ingredient_name]
     if new_ingredient_name.length > 30 || new_ingredient_name.blank? || former_ingredient_name.blank?
       render "posts/show", status: :unprocessable_entity
     end
     @post = Post.find(params[:post_id])
-    former_ingredients = @post.recipe_ingredients.to_json(only: [:name, :quantity])
-    former_steps = @post.recipe_steps.to_json(only: [:order, :instruction])
-    @response = JSON.parse(Openai::ApiResponseService.new.call(former_ingredient_name, new_ingredient_name,former_ingredients,former_steps))
+    former_ingredients = @post.recipe_ingredients.to_json(only: [ :name, :quantity ])
+    former_steps = @post.recipe_steps.to_json(only: [ :order, :instruction ])
+    @response = JSON.parse(Openai::ApiResponseService.new.call(former_ingredient_name, new_ingredient_name, former_ingredients, former_steps))
     @post_form = PostForm.new
-    if @response.include?('999')
+    if @response.include?("999")
       flash.now[:alert] = "食材を入力してください"
       render "posts/show", status: :unprocessable_entity
     end
@@ -27,16 +27,16 @@ class AiRecipesController < ApplicationController
 
   def check_csrf
     # Originが許可されていない場合はエラー
-    allowed_origins = ['https://oyasaiup.com', 'https://www.oyasaiup.com']
-    origin = request.headers['Origin']
+    allowed_origins = [ "https://oyasaiup.com", "https://www.oyasaiup.com" ]
+    origin = request.headers["Origin"]
 
     if origin.blank? || allowed_origins.exclude?(origin)
       raise CsrfProtectionError
     end
 
     # Sec-Fetch-Siteが存在していて許可されていない場合はエラー
-    allowed_values = ['same-origin', 'same-site']
-    sec_fetch_site = request.headers['Sec-Fetch-Site']
+    allowed_values = [ "same-origin", "same-site" ]
+    sec_fetch_site = request.headers["Sec-Fetch-Site"]
 
     if sec_fetch_site.present? && allowed_values.exclude?(sec_fetch_site.downcase)
       raise CsrfProtectionError

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -34,6 +34,7 @@ class PostsController < ApplicationController
       if post.draft?
         redirect_to post_path(post), notice: t("defaults.flash_message.created", item: "下書き")
       else
+        current_user.update(level: current_user.level + 1) if current_user.posts.published.count % 5 == 0
         redirect_to post_path(post), notice: t("defaults.flash_message.created", item: Post.model_name.human)
       end
     else

--- a/app/controllers/vegetable_logs_controller.rb
+++ b/app/controllers/vegetable_logs_controller.rb
@@ -1,8 +1,8 @@
 class VegetableLogsController < ApplicationController
   def create
     @vegetable_log = current_user.vegetable_logs.build(vegetable_log_params)
-    p @vegetable_log
     if @vegetable_log.save && @vegetable_log.calculate_total
+      current_user.update(level: current_user.level + 1) if current_user.vegetable_logs.count % 5 == 0 || current_user.vegetable_logs.count == 1
       redirect_to user_path(current_user), notice: t("defaults.flash_message.vegetable_log.recorded", item: VegetableLog.model_name.human)
     else
       redirect_to user_path(current_user), notice: t("defaults.flash_message.vegetable_log.not_recorded", item: VegetableLog.model_name.human), status: :unprocessable_entity

--- a/app/forms/post_form.rb
+++ b/app/forms/post_form.rb
@@ -112,13 +112,13 @@ class PostForm
   def no_blank_for_recipe_field
     if ingredients_name.nil?
       errors.add(:base, "材料が入力されていません")
-      return false
+      false
     elsif steps_instruction.nil?
       errors.add(:base, "作り方が入力されていません")
-      return false
+      false
     elsif ingredients_name.any?(&:blank?) || ingredients_quantity.any?(&:blank?) || steps_instruction.any?(&:blank?)
       errors.add(:base, "レシピ用フォームに空欄があります")
-      return false
+      false
     end
   end
 end

--- a/app/services/openai/api_response_service.rb
+++ b/app/services/openai/api_response_service.rb
@@ -1,14 +1,14 @@
 module Openai
   class ApiResponseService < BaseService
-    def call(former_ingredient_name, new_ingredient_name,former_ingredients,former_steps)
-      body = build_body(former_ingredient_name, new_ingredient_name,former_ingredients,former_steps)
-      response = post_request(url: '/v1/chat/completions', body: body)
+    def call(former_ingredient_name, new_ingredient_name, former_ingredients, former_steps)
+      body = build_body(former_ingredient_name, new_ingredient_name, former_ingredients, former_steps)
+      response = post_request(url: "/v1/chat/completions", body: body)
       extract_message_content(response)
     end
 
     private
 
-    def build_body(former_ingredient_name, new_ingredient_name,former_ingredients,former_steps)
+    def build_body(former_ingredient_name, new_ingredient_name, former_ingredients, former_steps)
       {
         model: @model,
         messages: [
@@ -48,11 +48,11 @@ module Openai
     def extract_message_content(response)
       response_hash = JSON.parse(response.body)
       content = response_hash.dig("choices", 0, "message", "content")
-      raise StandardError, 'レシピの情報が取得できませんでした。' unless content.present?
+      raise StandardError, "レシピの情報が取得できませんでした。" unless content.present?
 
       content
     rescue JSON::ParserError
-      raise StandardError, 'レシピの情報が取得できませんでした。'
+      raise StandardError, "レシピの情報が取得できませんでした。"
     end
   end
 end

--- a/app/services/openai/base_service.rb
+++ b/app/services/openai/base_service.rb
@@ -8,11 +8,11 @@ module Openai
   class BaseService
     attr_reader :model
 
-    def initialize(model: 'gpt-3.5-turbo', timeout: 10)
+    def initialize(model: "gpt-3.5-turbo", timeout: 10)
       @model = model
-      @connection = Faraday.new(url: 'https://api.openai.com') do |f|
-        f.headers['Authorization'] = "Bearer #{Rails.application.credentials.OPENAI_API_KEY}"
-        f.headers['Content-Type'] = 'application/json'
+      @connection = Faraday.new(url: "https://api.openai.com") do |f|
+        f.headers["Authorization"] = "Bearer #{Rails.application.credentials.OPENAI_API_KEY}"
+        f.headers["Content-Type"] = "application/json"
         f.options[:timeout] = timeout
         f.adapter Faraday.default_adapter
       end
@@ -20,12 +20,12 @@ module Openai
 
     protected
 
-    def post_request(url: '/', body: '{}')
+    def post_request(url: "/", body: "{}")
       response = @connection.post(url) { |req| req.body = body }
       handle_response_errors(response)
       response
     rescue Faraday::TimeoutError
-      raise TimeoutError, 'リクエストがタイムアウトしました。もう一度お試しください。'
+      raise TimeoutError, "リクエストがタイムアウトしました。もう一度お試しください。"
     end
 
     private
@@ -42,7 +42,7 @@ module Openai
       when 503
         raise ServiceUnavailableError, extract_message(response.body)
       else
-        raise StandardError, '不明なエラーです。'
+        raise StandardError, "不明なエラーです。"
       end
     end
 
@@ -55,7 +55,7 @@ module Openai
                           rescue JSON::ParserError
                             nil
                           end
-      extracted_message || 'エラーが発生しましたが、エラーメッセージが取得できませんでした。'
+      extracted_message || "エラーが発生しましたが、エラーメッセージが取得できませんでした。"
     end
   end
 end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -33,7 +33,7 @@
         </div>
         <div>
           <%= @user.name%>
-          <p>おやさいレベル</p>
+          <p class="text-secondary">おやさいLv.<%= @user.level%></p>
         </div>
       </div>
       <div class="mt-10 flex items-center">

--- a/db/migrate/20241206010633_add_level_to_users.rb
+++ b/db/migrate/20241206010633_add_level_to_users.rb
@@ -1,0 +1,5 @@
+class AddLevelToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :level, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_27_012834) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_06_010633) do
   create_table "bookmarks", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "post_id", null: false
@@ -85,6 +85,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_27_012834) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "avatar"
+    t.integer "level", default: 0, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
## issue番号
close #47 

## 概要
おやさいReport、おやさいLogの投稿数に応じ、ユーザーがレベルアップする機能を追加しました。

## 実施内容
- Userモデルにlevelカラムを追加
- おやさいLogの投稿日数5日ごとにレベルが1つ上昇するよう実装
- おやさいReportを5件投稿するごとにレベルが1つ上昇するよう実装
- ユーザーのレベルはマイページにて表示

## 備考
レベルが上がった際のフラッシュ表示を行うかは本リリース後に検討する
