### PR TITLE
AIプロンプトの修正

### DIFF
--- a/app/controllers/ai_recipes_controller.rb
+++ b/app/controllers/ai_recipes_controller.rb
@@ -12,8 +12,7 @@ class AiRecipesController < ApplicationController
     end
     @post = Post.find(params[:post_id])
     former_ingredients = @post.recipe_ingredients.to_json(only: [ :name, :quantity ])
-    former_steps = @post.recipe_steps.to_json(only: [ :order, :instruction ])
-    @response = JSON.parse(Openai::ApiResponseService.new.call(former_ingredient_name, new_ingredient_name, former_ingredients, former_steps))
+    @response = JSON.parse(Openai::ApiResponseService.new.call(former_ingredient_name, new_ingredient_name, former_ingredients))
     @post_form = PostForm.new
     if @response.include?("999")
       flash.now[:alert] = "食材を入力してください"

--- a/app/services/openai/api_response_service.rb
+++ b/app/services/openai/api_response_service.rb
@@ -1,14 +1,14 @@
 module Openai
   class ApiResponseService < BaseService
-    def call(former_ingredient_name, new_ingredient_name, former_ingredients, former_steps)
-      body = build_body(former_ingredient_name, new_ingredient_name, former_ingredients, former_steps)
+    def call(former_ingredient_name, new_ingredient_name, former_ingredients)
+      body = build_body(former_ingredient_name, new_ingredient_name, former_ingredients)
       response = post_request(url: "/v1/chat/completions", body: body)
       extract_message_content(response)
     end
 
     private
 
-    def build_body(former_ingredient_name, new_ingredient_name, former_ingredients, former_steps)
+    def build_body(former_ingredient_name, new_ingredient_name, former_ingredients)
       {
         model: @model,
         messages: [
@@ -18,16 +18,14 @@ module Openai
               "1.When a word '#{new_ingredient_name}' is invalid, your response should be '999'.
 
               # Invalid Cases:(Return '999')
-              - not a foodstuff
-              - meaningless words or phrases
+              - a word '#{new_ingredient_name}' is not a foodstuff
+              - a word '#{new_ingredient_name}' is meaningless words or phrases
 
               2.When a word '#{new_ingredient_name}' is valid, please provide a recipe with the following conditions.
 
               # a recipe to refer to
               Ingredients:
                 #{former_ingredients}
-              How to cook:
-                #{former_steps}
 
               # conditions
               Ingredients: replace #{former_ingredient_name} with #{new_ingredient_name}

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -85,10 +85,10 @@
 
   <div id="ai-recipe-form-for-post-<%= @post.id %>">
     <% if @post.with_recipe? && @post.published? %>
-      <h3>他の食材で作れるか試してみる</h3>
+      <h3 class="mt-20">材料が無い時は…</h3>
       <div class="text-center">
         <p class="mt-4">レシピの材料が家にない時や、お好みの食材で作ってみたい時はこちら！</p>
-        <p class="my-4">AIがレシピのアレンジをお手伝いします！</p>
+        <p class="mt-4 mb-10">AIがレシピのアレンジをお手伝いします！</p>
         <%= form_with url: ai_recipes_path do |f| %>
           <div class="flex items-center flex-col">
             <p class="my-2">このレシピの</p>


### PR DESCRIPTION
## 概要
AIのプロンプトを修正し、より自由にレシピを提案できるよう変更しました。

## 実施内容
- AIのプロンプトに、参考にするレシピの材料と作り方の手順を与えていたが、材料のみの提示に変更
- 手順を渡さないことで、指定された材料をもとにある程度自由にレシピを提案してもらえるようになった

## 備考
