### PR TITLE
[Fix] Linebotの設定方法の修正

### DIFF
--- a/app/controllers/linebots_controller.rb
+++ b/app/controllers/linebots_controller.rb
@@ -19,13 +19,27 @@ class LinebotsController < ApplicationController
     events = client.parse_events_from(body)
 
     events.each { |event|
+      user_id = event['source']['userId']
+      user = User.find_by(uid: user_id)
+      if event.message['text'].include?("リマインダ登録")
+        message = "リマインダを設定しました。毎日20時におやさいLogのリマインダを送信します。"
+        user.need_alert!
+      elsif event.message['text'].include?("リマインダ解除")
+        message = "おやさいLogのリマインダを解除しました。リマインダを再開したい時は「リマインダ登録」と送信してください。"
+        user.no_alert!
+      else
+        message = "このトークルームではおやさいLogのリマインダ設定の変更ができます。リマインダが必要な場合は「リマインダ登録」、解除したいときは「リマインダ解除」と送信してください。"
+      end
       case event
+      when Line::Bot::Event::Message
+        case event.type
+        when Line::Bot::Event::MessageType::Text
+          client.reply_message(event['replyToken'], message)
+        end
+      end
       when Line::Bot::Event::MessageType::Follow #友達登録イベント
-        userId = event['source']['userId']
-        User.find_or_create_by(uid: userId)
+        User.find_or_create_by(uid: user_id)
       when Line::Bot::Event::MessageType::Unfollow #友達削除イベント
-        userId = event['source']['userId']
-        user = User.find_by(uid: userId)
         user.update(uid: nil)
       end
     }

--- a/app/views/vegetable_logs/_form.html.erb
+++ b/app/views/vegetable_logs/_form.html.erb
@@ -1,5 +1,23 @@
 <h3>おやさい、食べた？</h3>
 <p class="my-8 text-center">どのくらいおやさいを食べたか、直感で記録しましょう！</p>
+<div role="alert" class="alert">
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    class="stroke-info h-6 w-6 shrink-0">
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+  </svg>
+  <span>LINEで友だち追加すると、毎日20時におやさいLog更新のリマインダが届きます</span>
+  <div class="line-it-button" data-lang="ja" data-type="friend" data-env="REAL"   data-lineId="@149ixjmn" style="display: none;"></div>
+  <script src="https://www.line-website.com/social-plugins/js/thirdparty/loader.min.js" async="async" defer="defer"></script>
+</div>
+
+
 <%= form_with model: @vegetable_log do |f| %>
   <%= f.label :breakfast,"朝ごはん", class: "label cursor-pointer" %>
   <%= f.range_field :breakfast, in: 0..10, class: "range range-secondary" %>


### PR DESCRIPTION
## issue番号
#49 

## 概要
LINEbotによるリマインダ機能の設定方法を変更し、LINEのトークルームで行えるようにしました。

## 実施内容
- 既存ユーザーがLINEの友達追加した場合、LINEのuidと既存ユーザーが紐づかないため、ユーザーのマイページでリマインダ設定が行えない問題が発生
- 上記に対処するため、LINEのトークルームで「リマインダ登録」「リマインダ解除」と送信すると設定変更ができるよう実装しました。

## 備考
LINEログインで利用しているユーザーはuidが紐づいているため、マイページでのリマインダ設定変更も可能となっています。