### PR TITLE
[Fix] CSRF用のエラークラスをapplication_controllerに定義

### DIFF
--- a/app/controllers/ai_recipes_controller.rb
+++ b/app/controllers/ai_recipes_controller.rb
@@ -1,5 +1,4 @@
 class AiRecipesController < ApplicationController
-  class CsrfProtectionError < StandardError; end
   before_action :authenticate_user!
 
   protect_from_forgery

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  class CsrfProtectionError < StandardError; end
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
   def ensure_correct_user


### PR DESCRIPTION
## issue番号
#49 

## 概要
csrfエラーに対応するためのメソッドのバグを修正しました

## 実施内容
メソッド内で使われるCsrfProtectionErrorクラスをapplication_controller内に定義していなかったためNameErrorが発生していました。

## 備考
