### PR TITLE
[Fix] CSRFエラー対応

### DIFF
--- a/app/controllers/linebots_controller.rb
+++ b/app/controllers/linebots_controller.rb
@@ -1,8 +1,7 @@
 class LinebotsController < ApplicationController
   require "line/bot"
 
-  protect_from_forgery
-  before_action :check_csrf
+  protect_from_forgery :except => [:callback]
 
   def client
     @client ||= Line::Bot::Client.new { |config|


### PR DESCRIPTION
## issue番号
#49 

## 概要
CSRFエラーに対応するため、linebotのcallbackメソッドのみprotect_from_forgeryを無効とする

## 実施内容
LINEbotがエラーにかかってしまいメソッドが実行できない。
linebotのcallbackメソッドでは署名による確認を行なっているため、一旦csrf検証を無効にする

## 備考
