### PR TITLE
[WIP]ユーザーの新規登録フォームにチェックボックスを追加、ローディングアニメーションの修正

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -42,7 +42,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # If you have extra params to permit, append them to the sanitizer.
   def configure_sign_up_params
-    devise_parameter_sanitizer.permit(:sign_up, keys: [ :name ])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [ :name, :registration_check ])
   end
 
   # If you have extra params to permit, append them to the sanitizer.

--- a/app/javascript/loading.js
+++ b/app/javascript/loading.js
@@ -2,3 +2,7 @@ document.addEventListener('turbo:load', ()=>{
   const spinner = document.getElementById("loading");
   spinner.classList.add("loaded");
 })
+document.addEventListener('turbo:render', ()=>{
+  const spinner = document.getElementById("loading");
+  spinner.classList.add("loaded");
+})

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   validates :name, presence: true, length: { maximum: 255 }
+  validates :registration_check, acceptance: true, on: :create
 
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -36,6 +36,13 @@
       <%= f.password_field :password_confirmation, autocomplete: "new-password", class: 'input input-bordered input-info form-control mb-6 w-full mx-auto' %>
     </div>
 
+    <div class="mx-auto flex items-center justify-center mt-16">
+      <%= f.label :registration_check, class: "label cursor-pointer" do %>
+        <%= f.check_box :registration_check, class: "checkbox checkbox-info mr-2" %>
+        <span><%= link_to "利用規約", term_path, class: "text-blue-500 hover:underline" %> および<%= link_to "プライバシーポリシー", policy_path, class: "text-blue-500 hover:underline" %>に同意しました。</span>
+      <% end %>
+    </div>
+
     <div class="actions">
       <%= f.submit class: 'btn btn-info w-full mt-6 mb-6 mx-auto' %>
     </div>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,11 +1,13 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation" data-turbo-cache="false", class="text-center">
-    <h2>
+  <div id="error_explanation" data-turbo-cache="false", class="mt-10 text-center">
+    <p class="text-xl">
       <%= I18n.t("errors.messages.not_saved",
                  count: resource.errors.count,
                  resource: resource.class.model_name.human.downcase)
        %>
-    </h2>
+    </p>
+  </div>
+  <div class="alert alert-danger bg-[#f6b827] text-white">
     <ul>
       <% resource.errors.full_messages.each do |message| %>
         <li><%= message %></li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,7 +35,7 @@
   </head>
 
   <body class="text-neutral">
-    <%= render "shared/loading" %>
+    
     <%= render "shared/header" %>
     <%= render "shared/flash_messages" %>
     <%= yield %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,7 +35,7 @@
   </head>
 
   <body class="text-neutral">
-    
+    <%= render "shared/loading" %>
     <%= render "shared/header" %>
     <%= render "shared/flash_messages" %>
     <%= yield %>

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -17,6 +17,7 @@ ja:
         locked_at: ロック時刻
         password: パスワード
         password_confirmation: パスワード（確認用）
+        registration_check: 利用規約、プライバシーポリシーチェック
         remember_created_at: ログイン記憶時刻
         remember_me: 次回から自動でログインする
         reset_password_sent_at: パスワードリセット送信時刻


### PR DESCRIPTION
## issue番号
#108 

## 概要
- ユーザーの新規登録フォームに、利用規約、プライバシーポリシーに同意した旨のチェックボックスを設置しました。
- フォームの登録失敗時、ローディングアニメーションが消えないバグが発生していたので対処しました。

## 実施内容
- ユーザーの新規登録時、利用規約、プライバシーポリシーに同意した旨のチェックボックスにチェックしないと登録できないよう実装
- フォームの登録失敗時にもローディングアニメーションが消えるよう修正

## 備考
