### PR TITLE
[WIP]投稿フォームの微修正、AIサポートフォームの微修正

### DIFF
--- a/app/javascript/loading.js
+++ b/app/javascript/loading.js
@@ -2,7 +2,3 @@ document.addEventListener('turbo:load', ()=>{
   const spinner = document.getElementById("loading");
   spinner.classList.add("loaded");
 })
-document.addEventListener('turbo:render', ()=>{
-  const spinner = document.getElementById("loading");
-  spinner.classList.add("loaded");
-})

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -2,5 +2,5 @@ class Tag < ApplicationRecord
   has_many :post_tags, dependent: :destroy
   has_many :posts, through: :post_tags
 
-  validates :name, uniqueness: true, presence: true
+  validates :name, uniqueness: true, presence: true, length: { maximum: 20 }
 end

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,25 +1,27 @@
 <%= form_with model: post_form, url: url,ingredients_form_count:ingredients_form_count,steps_form_count:steps_form_count  do |f| %>
   <%= render "shared/error_messages", object: f.object %>
+  <p class="text-center mb-10"><span class="text-red-600">*</span>は入力必須項目です。</p>
 
   <div class="field">
-    <%= f.label :title,Post.human_attribute_name(:title), class:"label w-full mx-auto" %>
-    <%= f.text_field :title, autofocus: true, autocomplete: "タイトル", class: 'input input-bordered input-info form-control mb-6 w-full mx-auto' %>
+    <span class="text-red-600">*</span>
+    <%= f.label :title,Post.human_attribute_name(:title), class:"w-full mx-auto font-bold" %>
+    <%= f.text_field :title, autofocus: true, autocomplete: "タイトル", class: 'input input-bordered input-info form-control mb-6 mt-2 w-full mx-auto' %>
   </div>
 
   <div class="field">
-    <%= f.label :post_image,Post.human_attribute_name(:post_image), class:"label w-full mx-auto" %>
+    <%= f.label :post_image,Post.human_attribute_name(:post_image), class:"label w-full mx-auto font-bold" %>
     <%= f.file_field :post_image, autocomplete: "ファイル", class: 'file-input file-input-bordered file-input-info form-control mb-6 w-full mx-auto text-neutral' %>
     <%= f.hidden_field :post_image_cache %>
     <%= image_tag(@post_form.post_image.url) if @post_form.post_image? %>
   </div>
 
   <div class="field">
-    <%= f.label :description,Post.human_attribute_name(:description), class:"label w-full mx-auto" %>
+    <%= f.label :description,Post.human_attribute_name(:description), class:"label w-full mx-auto font-bold" %>
     <%= f.text_area :description, autofocus: true, autocomplete: "詳細", class: 'textarea textarea-bordered textarea-info form-control mb-6 w-full mx-auto' %>
   </div>
 
   <div class="field">
-    <%= f.label :tag_names,Tag.model_name.human, class:"label w-full mx-auto" %>
+    <%= f.label :tag_names,Tag.model_name.human, class:"label w-full mx-auto font-bold" %>
     <%= f.text_field :tag_names, autofocus: true, autocomplete: ",で区切って入力してください", class: 'input input-bordered input-info form-control mb-2 w-full mx-auto' %>
     <div class="flex justify-center flex-wrap mb-6">
       <%= link_to 'コンビニ', '#', class: 'tag-link badge badge-ghost badge-lg mr-4 mt-4 mb-3' %>
@@ -32,18 +34,22 @@
   </div>
 
   <div class="field">
-    <%= f.label :mode,Post.human_attribute_name(:mode), class:"label w-full mx-auto" %>
+    <%= f.label :mode,Post.human_attribute_name(:mode), class:"label w-full mx-auto font-bold" %>
     <%= f.select :mode, Post.enum_options_for_select(:mode), {}, {id: 'mode', class: 'select select-bordered select-info w-full max-w-xs mb-6'} %>
   </div>
 
   <div id="recipe_fields" style="<%= "display:none" if @post_form.mode.nil? || @post_form.mode == 0 %>">
     <div class="field">
-      <%= f.label :serving,RecipeServing.model_name.human, class:"label w-full mx-auto" %>
-          <%= f.text_field :serving, class:'input input-bordered input-info form-control mb-6 inline w-16' %><p class="inline ml-2">人前</p>
+      <span class="text-red-600">*</span>
+      <%= f.label :serving,RecipeServing.model_name.human, class:"w-full mx-auto font-bold" %>
+      <div class="mt-2">
+        <%= f.text_field :serving, class:'input input-bordered input-info form-control mb-6 inline w-16' %><p class="inline ml-2">人前</p>
+      </div>
     </div>
 
-    <%= f.label :ingredients,RecipeIngredient.model_name.human, class:"label w-full mx-auto" %>
-    <div id="ingredient_fields" class="field">
+    <span class="text-red-600">*</span>
+    <%= f.label :ingredients,RecipeIngredient.model_name.human, class:"w-full mx-auto font-bold" %>
+    <div id="ingredient_fields" class="field mt-2">
       <% ingredients_form_count.times do |index| %>
         <div class="flex">
             <%= f.text_field :ingredients_name, name: "post_form[ingredients_name][]", value: post_form.ingredients_name[index], placeholder: "材料名", class:'input input-bordered input-info form-control mb-2 mr-1 w-full mx-auto basis-4/6' %>
@@ -54,8 +60,9 @@
     </div>
     <div class="text-center"><button id="add_ingredient_button"  type="button" class="btn btn-info mt-2 mb-6 mx-auto">+ 材料を追加</button></div>
 
-    <%= f.label :steps,RecipeStep.model_name.human, class:"label w-full mx-auto" %>
-    <div id="step_fields" class="field">
+    <span class="text-red-600">*</span>
+    <%= f.label :steps,RecipeStep.model_name.human, class:"w-full mx-auto font-bold" %>
+    <div id="step_fields" class="field mt-2">
       <% steps_form_count.times do |index| %>
         <div class="flex items-center mb-2">
             <div class="inline w-10 h-10 rounded-full bg-[#8DBA30] text-center leading-10"><%= index+1 %></div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -94,7 +94,7 @@
             <p class="my-2">このレシピの</p>
             <%= f.select(:former_ingredient_name, @ingredient_names, { include_blank: "選択してください" }, class: "select select-primary w-full max-w-xs") %>
             <p class="my-2">を</p>
-            <%= f.text_field(:new_ingredient_name, class:"input input-bordered input-primary w-full max-w-xs", placeholder: "食材を入力") %>
+            <%= f.text_field(:new_ingredient_name, class:"input input-bordered input-primary w-full max-w-xs", placeholder: "30字以内で食材を入力") %>
             <p class="mt-2">に変えたら…？</p>
           </div>
           <%= f.hidden_field :post_id, value: @post.id %>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -29,6 +29,8 @@ ja:
         id: ID
         created_by: 作成者
         created_at: 作成日時
+      tag:
+        name: タグ
       post/mode:
         without_recipe: レシピなし
         with_recipe: レシピ付き


### PR DESCRIPTION
## issue番号
#108 

## 概要
各種フォームの調整を行いました

## 実施内容
- 投稿フォームの入力必須欄に印をつけました
- 投稿フォームのタグに20字の字数制限を設定しました
- AIサポートフォームのplaceholderに30字までの字数制限を明記しました

## 備考
前回のPRでデプロイが失敗していた。原因特定のため、一度loading用のJSファイルの記述を元に戻している。