### PR TITLE
[Fix] AIサポートフォーム、ユーザー新規登録フォームの修正

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -21,7 +21,7 @@ h3 {
 .container {
   width: 80%;
   margin: 20px auto;
-  padding: 80px 0;
+  padding-bottom: 80px;
 }
 .form-container {
   max-width: 800px;

--- a/app/controllers/ai_recipes_controller.rb
+++ b/app/controllers/ai_recipes_controller.rb
@@ -5,11 +5,16 @@ class AiRecipesController < ApplicationController
   before_action :check_csrf
 
   def create
+    @post = Post.find(params[:post_id])
+    @ingredient_names = @post.recipe_ingredients.pluck(:name)
     former_ingredient_name, new_ingredient_name = params[:former_ingredient_name], params[:new_ingredient_name]
-    if new_ingredient_name.length > 30 || new_ingredient_name.blank? || former_ingredient_name.blank?
+    if new_ingredient_name.length > 20 || new_ingredient_name.blank?
+      flash.now[:alert] = "20字以内で食材を入力してください"
+      render "posts/show", status: :unprocessable_entity
+    elsif former_ingredient_name.blank?
+      flash.now[:alert] = "置き換える食材を選択してください"
       render "posts/show", status: :unprocessable_entity
     end
-    @post = Post.find(params[:post_id])
     former_ingredients = @post.recipe_ingredients.to_json(only: [ :name, :quantity ])
     @response = JSON.parse(Openai::ApiResponseService.new.call(former_ingredient_name, new_ingredient_name, former_ingredients))
     @post_form = PostForm.new
@@ -18,6 +23,7 @@ class AiRecipesController < ApplicationController
       render "posts/show", status: :unprocessable_entity
     end
   rescue => e
-    render json: { error: e.message }, status: :internal_server_error
+    flash.now[:alert] = "エラーが発生しました"
+    render "posts/show", status: :internal_server_error
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  validates :name, presence: true, length: { maximum: 255 }
+  validates :name, presence: true, length: { maximum: 10 }
   validates :registration_check, acceptance: true, on: :create
 
   devise :database_authenticatable, :registerable,

--- a/app/services/openai/api_response_service.rb
+++ b/app/services/openai/api_response_service.rb
@@ -36,7 +36,7 @@ module Openai
               - title
               - ingredients:(no more than 6, format: keys for JSON should be ingredient_name and values for JSON should be quantity)
               - steps:(less than 8 steps, format: keys for JSON should be step_number and values for JSON should be instruction)
-              - tips:(tips for cooking)"
+              - tips:(values for JSON should be tips for cooking)"
           }
         ],
         response_format: { "type": "json_object" }

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -15,25 +15,38 @@
 
   <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
     <%= render "devise/shared/error_messages", resource: resource %>
+    <p class="text-center mt-4 mb-10"><span class="text-red-600">*</span>は入力必須項目です。</p>
 
     <div class="field">
-      <%= f.label :name, class:"label w-full mx-auto" %>
-      <%= f.text_field :name, autofocus: true, autocomplete: "ユーザー名", class: 'input input-bordered input-info form-control mb-6 w-full mx-auto' %>
+      <%= f.label :name, class:"w-full mx-auto" do %>
+        <span class="text-red-600">*</span>
+        <%= User.human_attribute_name(:name) %>
+      <% end%>
+      <%= f.text_field :name, autofocus: true, autocomplete: "ユーザー名", class: 'input input-bordered input-info form-control mb-6 w-full mx-auto mt-2', placeholder: "10文字以下" %>
     </div>
 
     <div class="field">
-      <%= f.label :email, class:"label w-full mx-auto" %>
-      <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'input input-bordered input-info form-control mb-6 w-full mx-auto' %>
+      <%= f.label :email, class:"w-full mx-auto" do %>
+        <span class="text-red-600">*</span>
+        <%= User.human_attribute_name(:email) %>
+      <% end%>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'input input-bordered input-info form-control mb-6 w-full mx-auto mt-2', placeholder: "メールアドレスを入力" %>
     </div>
 
     <div class="field">
-      <%= f.label :password, class:"label w-full mx-auto" %>
-      <%= f.password_field :password, autocomplete: "new-password", class: 'input input-bordered input-info form-control mb-6 w-full mx-auto' %>
+      <%= f.label :password, class:"w-full mx-auto" do %>
+        <span class="text-red-600">*</span>
+        <%= User.human_attribute_name(:password) %>
+      <% end%>
+      <%= f.password_field :password, autocomplete: "new-password", class: 'input input-bordered input-info form-control mb-6 w-full mx-auto mt-2', placeholder: "6文字以上" %>
     </div>
 
     <div class="field">
-      <%= f.label :password_confirmation, class:"label w-full mx-auto" %>
-      <%= f.password_field :password_confirmation, autocomplete: "new-password", class: 'input input-bordered input-info form-control mb-6 w-full mx-auto' %>
+      <%= f.label :password_confirmation, class:"w-full mx-auto" do %>
+        <span class="text-red-600">*</span>
+        <%= User.human_attribute_name(:password_confirmation) %>
+      <% end%>
+      <%= f.password_field :password_confirmation, autocomplete: "new-password", class: 'input input-bordered input-info form-control mb-6 w-full mx-auto mt-2', placeholder: "パスワードをもう一度" %>
     </div>
 
     <div class="mx-auto flex items-center justify-center mt-16">

--- a/app/views/posts/_bookmark_buttons.html.erb
+++ b/app/views/posts/_bookmark_buttons.html.erb
@@ -1,7 +1,7 @@
 <div class='ms-auto'>
   <% if current_user.bookmark?(post) %>
-    <%= render 'unbookmark', { post: post } %>
+    <%= render 'posts/unbookmark', { post: post } %>
   <% else %>
-    <%= render 'bookmark', { post: post } %>
+    <%= render 'posts/bookmark', { post: post } %>
   <% end %>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -23,7 +23,7 @@
         </svg>
       <% end %>
       <% if current_user && !current_user.own?(@post) %>
-        <%= render "bookmark_buttons", { post: @post } %>
+        <%= render "posts/bookmark_buttons", { post: @post } %>
       <% end %>
     </div>
     <div class="sm:flex sm:mt-10 mt-4 justify-between items-center w-full">
@@ -94,7 +94,7 @@
             <p class="my-2">このレシピの</p>
             <%= f.select(:former_ingredient_name, @ingredient_names, { include_blank: "選択してください" }, class: "select select-primary w-full max-w-xs") %>
             <p class="my-2">を</p>
-            <%= f.text_field(:new_ingredient_name, class:"input input-bordered input-primary w-full max-w-xs", placeholder: "30字以内で食材を入力") %>
+            <%= f.text_field(:new_ingredient_name, class:"input input-bordered input-primary w-full max-w-xs", placeholder: "20字以内で食材を入力") %>
             <p class="mt-2">に変えたら…？</p>
           </div>
           <%= f.hidden_field :post_id, value: @post.id %>

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -9,7 +9,7 @@ ja:
         current_password: 現在のパスワード
         current_sign_in_at: 現在のログイン時刻
         current_sign_in_ip: 現在のログインIPアドレス
-        email: Eメール
+        email: メールアドレス
         encrypted_password: 暗号化パスワード
         failed_attempts: 失敗したログイン試行回数
         last_sign_in_at: 最終ログイン時刻


### PR DESCRIPTION
## issue番号
close #108 

## 概要
AIサポートフォーム、ユーザー新規登録フォームの修正を行いました

## 実施内容
- AIフォームが空欄/20字以上のバリデーションにかかった場合、フラッシュメッセージが表示されるよう修正しました
- ユーザー新規登録フォームの入力必須マークを明記しました
- ユーザー新規登録フォームのplaceholderを追加しました

## 備考
「ユーザー新規登録フォームの全項目入力が完了するまで、登録ボタンが押せないようにする」は実装せず、上記対応とした。
JavaScript等で実装するか本リリース後に検討する