### PR TITLE
[Fix]LINEログイン時の処理の変更

### DIFF
--- a/app/controllers/linebots_controller.rb
+++ b/app/controllers/linebots_controller.rb
@@ -42,8 +42,10 @@ class LinebotsController < ApplicationController
           }
           client.reply_message(event["replyToken"], message)
         when Line::Bot::Event::MessageType::Follow # 友達登録イベント
-          User.find_or_create_by(uid: user_id)
+          user = User.find_or_create_by(uid: user_id)
+          user.need_alert!
         when Line::Bot::Event::MessageType::Unfollow # 友達削除イベント
+          user.no_alert!
           user.update(uid: nil)
         end
       end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -43,9 +43,14 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       end
       @profile.set_values(@omniauth)
       sign_in(:user, @profile)
+
+      flash[:notice] = "ログインしました"
+      redirect_to user_path(current_user)
+    else
+      flash[:alert] = "認証に失敗しました"
+      redirect_to user_session_path
     end
-    flash[:notice] = "ログインしました"
-    redirect_to user_path(current_user)
+
   end
 
   def fake_email(uid, provider)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,7 +15,7 @@ class User < ApplicationRecord
 
   mount_uploader :avatar, AvatarUploader
 
-  enum :line_alert, { need_alert: 0, no_alert: 1 }, validate: true
+  enum :line_alert, { no_alert: 0, need_alert: 1 }, validate: true
 
   def own?(object)
     id == object&.user_id


### PR DESCRIPTION
## issue番号
#49 

## 概要
LINEログイン/友達追加した際の処理を変更しました

## 実施内容
- デフォルトではおやさいLogリマインダが送信されないよう変更
- LINEで友達追加するとおやさいLogリマインダが送信されるよう自動設定
- LINEで友達削除するとおやさいLogリマインダが送信されないよう自動設定

## 備考
