### PR TITLE
[Fix] LINEのリマインダ設定をプロフィール編集画面から削除

### DIFF
--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -16,14 +16,7 @@
       <%= image_tag(@user.avatar.url) if @user.avatar? %>
     </div>
 
-    <% if @user.uid.present? %>
-      <div class="field mt-10">
-        <%= f.label :line_alert,User.human_attribute_name(:line_alert), class:"label w-full mx-auto" %>
-        <%= f.collection_radio_buttons :line_alert, User.enum_options_for_radio(:line_alert), :last , :first do |b|  %>
-          <% b.label(class: "label cursor-pointer justify-start") { b.radio_button(class: "radio radio-primary") + b.text } %>
-        <% end %>
-      </div>
-    <% end %>
+
 
     <div class="actions mt-16">
       <%= f.submit '登録', class: 'btn btn-info w-full mt-6 mb-6 mx-auto' %>


### PR DESCRIPTION
## 概要
LINEのリマインダ設定をプロフィール編集画面から削除しました

## 背景
現状、LINEログインしてLINEの友達追加を行なっていない場合も、プロフィール編集画面でLINEのおやさいLogリマインダ設定ができてしまう。その場合「リマインダを送信する」と設定してもLINEの友達追加をしないとリマインダ送信されない。この設定表示がミスリーディングなため、リマインダ設定はLINEの公式アカウントのトークルームからのみ変更できるようにすることとした。

## できなくなること（ユーザー目線）
- プロフィール画面でLINEのおやさいLogリマインダ設定ができなくなります

## 備考
