### PR TITLE
[Add] トップページに使い方の説明を追加

### DIFF
--- a/app/assets/images/check-primary.svg
+++ b/app/assets/images/check-primary.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#617b47"><path d="M382-240 154-468l57-57 171 171 367-367 57 57-424 424Z"/></svg>

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -7,7 +7,7 @@ h2 {
   margin-top: 1.5rem;
   margin-bottom: 1.5rem;
   text-align: center;
-  font-size: 2.5rem;
+  font-size: 2.25rem;
   line-height: 2.25rem;
   font-weight: bold;
 }
@@ -74,4 +74,11 @@ h3 {
 .loaded {
   opacity: 0;
   visibility: hidden;
+}
+
+/* 481px以上に適用（タブレット以上） */
+@media screen and (min-width: 481px) {
+	h2 {
+    font-size: 2.5rem;
+  }
 }

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -35,13 +35,24 @@ h3 {
 }
 
 /* トップページ */
-.curved {
+.curved-accent {
   position: relative;
   background: #f6b827;
 
   border-top-left-radius: 50% 10%;
   border-top-right-radius: 50% 10%;
+  border-bottom-left-radius: 50% 10%;
+  border-bottom-right-radius: 50% 10%;
 }
+
+.curved-primary {
+  position: relative;
+  background: #617b47;
+
+  border-top-left-radius: 50% 10%;
+  border-top-right-radius: 50% 10%;
+}
+
 
 /* 投稿カード */
 .card {

--- a/app/controllers/ai_recipes_controller.rb
+++ b/app/controllers/ai_recipes_controller.rb
@@ -1,5 +1,5 @@
 class AiRecipesController < ApplicationController
-  before_action :authenticate_user!
+  before_action :authenticate_user!, except: %i[ create ]
 
   protect_from_forgery
   before_action :check_csrf

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,7 +4,11 @@ class PostsController < ApplicationController
 
   def index
     @q = Post.ransack(params[:q])
-    @posts =  @q.result(distinct: true).published.includes(:user).order(created_at: :desc).page(params[:page])
+    @posts =  if (tag_name = params[:tag_name])
+                @q.result(distinct: true).with_tag(tag_name).published.includes(:user).order(created_at: :desc).page(params[:page])
+              else
+                @q.result(distinct: true).published.includes(:user).order(created_at: :desc).page(params[:page])
+              end
   end
 
   def new

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -15,6 +15,8 @@ class Post < ApplicationRecord
   enum :mode, { without_recipe: 0, with_recipe: 10 }, validate: true
   enum :status, { published: 0, draft: 1 }, validate: true
 
+  scope :with_tag, ->(tag_name) { joins(:tags).where(tags: { name: tag_name }) }
+
   def save_tag(sent_tags)
     sent_tags.uniq!
     current_tags = self.tags.pluck(:name) unless self.tags.nil?

--- a/app/views/ai_recipes/create.turbo_stream.erb
+++ b/app/views/ai_recipes/create.turbo_stream.erb
@@ -45,7 +45,7 @@
           <div class="mt-4 md:mt-10">
             <% @response["steps"].each do |key,value|%>
               <div class="flex items-start mb-4">
-                <div class="inline w-8 h-8 rounded-full bg-accent text-neutral text-center leading-8 mr-1 shrink-0"><%= key %></div>
+                <div class="inline w-8 h-8 rounded-full bg-[#f6b827] text-neutral text-center leading-8 mr-1 shrink-0"><%= key %></div>
                 <p class=""><%= value %></p>
               </div>
             <% end %>

--- a/app/views/ai_recipes/create.turbo_stream.erb
+++ b/app/views/ai_recipes/create.turbo_stream.erb
@@ -57,22 +57,23 @@
     <p class="text-xl font-bold md:mb-8">調理のコツ</p>
     <p><%= @response["tips"] %></p>
   </div>
-  <%= form_with model: @post_form, url: posts_path do |f| %>
-    <%= f.hidden_field :title, name: "post_form[title]", value: @response["title"] %>
-    <%= f.hidden_field :description,name: "post_form[description]", value: @response["tips"] %>
-    <%= f.hidden_field :tag_names, name: "post_form[tag_names]", value: "AIによる提案レシピ" %>
-    <%= f.hidden_field :mode,name: "post_form[mode]", value: "10" %>
-    <%= f.hidden_field :serving, value: @post.recipe_serving.serving %>
-    <% @response["ingredients"].each do |key,value| %>
-      <%= f.hidden_field :ingredients_name, name: "post_form[ingredients_name][]", value: key %>
-      <%= f.hidden_field :ingredients_quantity, name: "post_form[ingredients_quantity][]",value: value %>
+  <% if current_user %>
+    <%= form_with model: @post_form, url: posts_path do |f| %>
+      <%= f.hidden_field :title, name: "post_form[title]", value: @response["title"] %>
+      <%= f.hidden_field :description,name: "post_form[description]", value: @response["tips"] %>
+      <%= f.hidden_field :tag_names, name: "post_form[tag_names]", value: "AIによる提案レシピ" %>
+      <%= f.hidden_field :mode,name: "post_form[mode]", value: "10" %>
+      <%= f.hidden_field :serving, value: @post.recipe_serving.serving %>
+      <% @response["ingredients"].each do |key,value| %>
+        <%= f.hidden_field :ingredients_name, name: "post_form[ingredients_name][]", value: key %>
+        <%= f.hidden_field :ingredients_quantity, name: "post_form[ingredients_quantity][]",value: value %>
+      <% end %>
+      <% @response["steps"].each do |key,value| %>
+        <%= f.hidden_field :steps_instruction, name: "post_form[steps_instruction][]",value: value %>
+      <% end %>
+      <div class="mt-4 md:mt-16 text-center">
+        <%= f.submit t("form.draft"), name: "draft", class: 'btn btn-accent text-neutral' %>
+      </div>
     <% end %>
-    <% @response["steps"].each do |key,value| %>
-      <%= f.hidden_field :steps_instruction, name: "post_form[steps_instruction][]",value: value %>
-    <% end %>
-    <div class="mt-4 md:mt-16 text-center">
-      <%= f.submit t("form.draft"), name: "draft", class: 'btn btn-accent text-neutral' %>
-    </div>
   <% end %>
-  
 <% end %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,6 +1,17 @@
 <div class="container">
   <h2><%= t('.title') %></h2>
   <%= render 'search_form', q: @q, url: posts_path %>
+  <p class="text-center text-xl font-bold mt-16">おすすめのタグ</h3>
+  <div class="mb-10">
+    <div class="flex justify-center flex-wrap mb-6">
+      <%= link_to 'コンビニ', posts_path(tag_name: "コンビニ"), class: 'badge badge-outline badge-lg hover:text-secondary hover:duration-100 mr-4 mt-4 mb-3' %>
+      <%= link_to 'スーパー', posts_path(tag_name: "スーパー"), class: 'badge badge-outline badge-lg hover:text-secondary hover:duration-100 mr-4 mt-4 mb-3' %>
+      <%= link_to '外食', posts_path(tag_name: "外食"), class: 'badge badge-outline badge-lg hover:text-secondary hover:duration-100 mr-4 mt-4 mb-3' %>
+      <%= link_to '自炊', posts_path(tag_name: "自炊"), class: 'badge badge-outline badge-lg hover:text-secondary hover:duration-100 mr-4 mt-4 mb-3' %>
+      <%= link_to 'デリバリー', posts_path(tag_name: "デリバリー"), class: 'badge badge-outline badge-lg hover:text-secondary hover:duration-100 mr-4 mt-4 mb-3' %>
+      <%= link_to '包丁・まな板不要', posts_path(tag_name: "包丁・まな板不要"), class: 'badge badge-outline badge-lg hover:text-secondary hover:duration-100 mr-4 mt-4 mb-3' %>
+    </div>
+  </div>
   <% if @posts.present? %>
     <div class="mt-10 grid grid-cols-1 md:grid-cols-2 gap-8 xl:grid-cols-3 xl:gap-6 break-words">
       <%= render @posts %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -113,6 +113,7 @@
           <div class="mt-10">
             <%= f.submit "AIに提案してもらう", class: "btn btn-secondary text-white" %>
           </div>
+          <span class="text-red-600">※AIの提案レシピの保存には事前にログインが必要です</span>
         <% end %>
       </div>
     <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -12,7 +12,7 @@
     <% end %>
     <% if @post.tags.present? %>
       <% @post.tags.each do |tag| %>
-        <div class="badge badge-outline md:badge-lg badge-sm"><%= tag.name %></div>
+        <%= link_to tag.name, posts_path(tag_name: tag.name), class: 'badge badge-outline md:badge-lg badge-sm hover:text-secondary hover:duration-100' %>
       <% end %>
     <% end %>
     <div class="mx-auto w-10/12 mt-4 rounded-md flex justify-center">
@@ -32,7 +32,7 @@
         <%= render "posts/bookmark_buttons", { post: @post } %>
       <% end %>
     </div>
-    <div class="sm:flex sm:mt-10 mt-4 justify-between items-center w-full">
+    <div class="flex sm:mt-10 mt-4 justify-between items-center w-full flex-wrap">
       <%= link_to user_path(@post.user), class: "flex items-center text-lg underline underline-offset-4 hover:text-secondary hover:duration-100" do %>
         <div class="avatar mr-2">
           <div class="w-16 rounded-full">
@@ -113,7 +113,9 @@
           <div class="mt-10">
             <%= f.submit "AIに提案してもらう", class: "btn btn-secondary text-white" %>
           </div>
-          <span class="text-red-600">※AIの提案レシピの保存には事前にログインが必要です</span>
+          <% if !current_user %>
+            <span class="text-red-600">※AIの提案レシピの保存には事前にログインが必要です</span>
+          <% end %>
         <% end %>
       </div>
     <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -129,9 +129,9 @@
 </div>
 
 <script>
-  const newIngredientNameField = document.getElementById('new_ingredient_name');
-  const length = document.querySelector('.length');
-  const maxLength = 20
+  let newIngredientNameField = document.getElementById('new_ingredient_name');
+  let length = document.querySelector('.length');
+  let maxLength = 20
   newIngredientNameField.addEventListener('input', () => {
     length.textContent = maxLength - newIngredientNameField.value.length;
     if(maxLength - newIngredientNameField.value.length < 0){

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -2,14 +2,14 @@
   <div class="container flex flex-col justify-center items-center">
     <p class="mt-28">お野菜摂取の応援アプリ</p>
     <h1 class="text-5xl font-bold mt-4 mb-20">おやさいUP</h1>
-    <div class="flex ">
-      <%= link_to "新規登録",new_user_registration_path, class: "btn btn-primary text-white mr-2" %>
+    <div class="flex">
+      <%= link_to "使ってみる",posts_path, class: "btn btn-primary text-white mr-2" %>
       <%= link_to "ログイン",new_user_session_path, class: "btn btn-secondary text-white" %>
     </div>
   </div>
 </section>
 
-<section class="curved">
+<section class="curved-accent">
   <div class="container flex flex-col justify-center items-center">
     <h3 class="mt-20">おやさいUPとは</h3>
     <div class="w-2/3">
@@ -26,3 +26,149 @@
     </div>
   </div>
 </section>
+
+<section>
+  <div class="py-8 px-4 mx-auto max-w-screen-xl lg:py-16 lg:px-6">
+      <div class="mx-auto max-w-screen-md text-center mb-8 lg:mb-12">
+          <h3>おやさいUPでできること</h3>
+      </div>
+      <div class="space-y-8 lg:grid lg:grid-cols-3 sm:gap-6 xl:gap-10 lg:space-y-0">
+          <!-- Card -->
+          <div class="flex flex-col p-6 mx-auto max-w-lg text-center bg-white rounded-lg border border-gray-100 shadow xl:p-8">
+              <h4 class="mb-4 text-2xl font-semibold">おやさいReportで<br>レシピをチェック！</h4>
+              <div class="flex justify-center items-baseline my-8">
+                  <%= image_tag 'carrot.png'%>
+              </div>
+              <!-- List -->
+              <ul role="list" class="mb-4 space-y-4 text-left">
+                  <li class="flex items-center space-x-3">
+                      <!-- Icon -->
+                      <%= image_tag 'check-primary.svg', class: 'h-6 w-6 mr-2' %>
+                      <span>気になる料理のレシピを確認</span>
+                  </li>
+                  <li class="flex items-center space-x-3">
+                      <!-- Icon -->
+                      <%= image_tag 'check-primary.svg', class: 'h-6 w-6 mr-2' %>
+                      <span>食材名、レシピの有無で検索可能</span>
+                  </li>
+              </ul>
+          </div>
+          <!-- Card -->
+          <div class="flex flex-col p-6 mx-auto max-w-lg text-center bg-white rounded-lg border border-gray-100 shadow xl:p-8">
+              <h4 class="mb-4 text-2xl font-semibold">タグ検索で<br>手軽なお野菜補給アイデアをゲット！</h4>
+              <div class="flex justify-center items-baseline my-8">
+                  <%= image_tag 'post_default.png'%>
+              </div>
+              <!-- List -->
+              <ul role="list" class="mb-4 space-y-4 text-left">
+                  <li class="flex items-center space-x-3">
+                      <!-- Icon -->
+                      <%= image_tag 'check-primary.svg', class: 'h-6 w-6 mr-2' %>
+                      <span>「コンビニ」「外食」などのタグで検索</span>
+                  </li>
+                  <li class="flex items-center space-x-3">
+                      <!-- Icon -->
+                      <%= image_tag 'check-primary.svg', class: 'h-6 w-6 mr-2' %>
+                      <span>調理不要なお手軽アイデアを確認</span>
+                  </li>
+              </ul>
+          </div>
+          <!-- Card -->
+          <div class="flex flex-col p-6 mx-auto max-w-lg text-center bg-white rounded-lg border border-gray-100 shadow xl:p-8">
+              <h4 class="mb-4 text-2xl font-semibold">レシピの食材がないときは<br>AIに相談！</h4>
+              <div class="flex justify-center items-baseline my-8">
+                <a href="https://gyazo.com/63699efd6add0f13236706903cf2f7d8"><img src="https://i.gyazo.com/63699efd6add0f13236706903cf2f7d8.png" alt="Image from Gyazo" width="630"/></a>
+              </div>
+              <!-- List -->
+              <ul role="list" class="mb-4 space-y-4 text-left">
+                  <li class="flex items-center space-x-3">
+                      <!-- Icon -->
+                      <%= image_tag 'check-primary.svg', class: 'h-6 w-6 mr-2' %>
+                      <span>家にある食材でレシピをアレンジ</span>
+                  </li>
+                  <li class="flex items-center space-x-3">
+                      <!-- Icon -->
+                      <%= image_tag 'check-primary.svg', class: 'h-6 w-6 mr-2' %>
+                      <span>投稿されたレシピを元に、AIが新しいレシピを提案</span>
+                  </li>
+              </ul>
+              <span class="text-red-600">※AIの提案レシピの保存にはログインが必要です</span>
+          </div>
+      </div>
+  </div>
+</section>
+
+<section>
+  <div class="py-8 px-4 mx-auto max-w-screen-xl lg:py-16 lg:px-6">
+      <div class="mx-auto max-w-screen-md text-center mb-8 lg:mb-12">
+          <h3>ログインすると、もっと便利！</h3>
+      </div>
+      <div class="space-y-8 lg:grid lg:grid-cols-3 sm:gap-6 xl:gap-10 lg:space-y-0">
+          <!-- Card -->
+          <div class="flex flex-col p-6 mx-auto max-w-lg text-center bg-white rounded-lg border border-gray-100 shadow xl:p-8">
+              <h4 class="mb-4 text-2xl font-semibold">おやさいReportの下書き・投稿</h4>
+              <div class="flex justify-center items-baseline my-8">
+              <a href="https://gyazo.com/efa5ad4fde6fa253303899c94205c35f"><img src="https://i.gyazo.com/efa5ad4fde6fa253303899c94205c35f.gif" alt="Image from Gyazo" width="856"/></a>
+              </div>
+              <!-- List -->
+              <ul role="list" class="mb-4 space-y-4 text-left">
+                  <li class="flex items-center space-x-3">
+                      <!-- Icon -->
+                      <%= image_tag 'check-primary.svg', class: 'h-6 w-6 mr-2' %>
+                      <span>レシピの覚え書きや、アイデアの備忘録に！</span>
+                  </li>
+                  <li class="flex items-center space-x-3">
+                      <!-- Icon -->
+                      <%= image_tag 'check-primary.svg', class: 'h-6 w-6 mr-2' %>
+                      <span>下書き保存で時間のある時に投稿できる！</span>
+                  </li>
+              </ul>
+          </div>
+          <!-- Card -->
+          <div class="flex flex-col p-6 mx-auto max-w-lg text-center bg-white rounded-lg border border-gray-100 shadow xl:p-8">
+              <h4 class="mb-4 text-2xl font-semibold">おやさいLogで<br>日々のお野菜摂取を記録</h4>
+              <div class="flex justify-center items-baseline my-8">
+              <a href="https://gyazo.com/fe3e5748662b14e4b54c4aa40e59ba49"><img src="https://i.gyazo.com/fe3e5748662b14e4b54c4aa40e59ba49.gif" alt="Image from Gyazo" width="852"/></a>
+              </div>
+              <!-- List -->
+              <ul role="list" class="mb-4 space-y-4 text-left">
+                  <li class="flex items-center space-x-3">
+                      <!-- Icon -->
+                      <%= image_tag 'check-primary.svg', class: 'h-6 w-6 mr-2' %>
+                      <span>毎食お野菜を食べたかどうか、直感でゆるっと記録</span>
+                  </li>
+                  <li class="flex items-center space-x-3">
+                      <!-- Icon -->
+                      <%= image_tag 'check-primary.svg', class: 'h-6 w-6 mr-2' %>
+                      <span>LINEで公式アカウントを追加し、入力のリマインダを受け取ろう！</span>
+                  </li>
+              </ul>
+          </div>
+          <!-- Card -->
+          <div class="flex flex-col p-6 mx-auto max-w-lg text-center bg-white rounded-lg border border-gray-100 shadow xl:p-8">
+              <h4 class="mb-4 text-2xl font-semibold">気になるおやさいReportを<br>ブックマークに保存</h4>
+              <div class="flex justify-center items-baseline my-8">
+              <a href="https://gyazo.com/0d587f0351a5e86ed7e91984c0efe0ef"><img src="https://i.gyazo.com/0d587f0351a5e86ed7e91984c0efe0ef.gif" alt="Image from Gyazo" width="856"/></a>
+              </div>
+              <!-- List -->
+              <ul role="list" class="mb-4 space-y-4 text-left">
+                  <li class="flex items-center space-x-3">
+                      <!-- Icon -->
+                      <%= image_tag 'check-primary.svg', class: 'h-6 w-6 mr-2' %>
+                      <span>気になる投稿はブックマークに保存</span>
+                  </li>
+                  <li class="flex items-center space-x-3">
+                      <!-- Icon -->
+                      <%= image_tag 'check-primary.svg', class: 'h-6 w-6 mr-2' %>
+                      <span>ブックマーク一覧でいつでもチェック！</span>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+</section>
+
+<div class="text-center mb-40">
+  <%= link_to "ログイン/新規登録",new_user_session_path, class: "btn btn-secondary text-white" %>
+</div>
+


### PR DESCRIPTION
## issue番号
#115 

## 概要
トップ画面にアプリの使用方法説明を追加しました

## 実施内容
- gyazoを使用し、画像と動画で表示
- ログイン/未ログイン時の使用可能機能を整理
- おすすめのタグによる検索機能を追加

## 備考
- ブックマーク一覧でタグの絞り込みが必要かどうかは別途検討する
- 本番環境にタグでの絞り込み画面が反映してから、使用説明動画をアップデート予定