### PR TITLE
お問合せフォームのリンクをHTML埋め込みように修正

### DIFF
--- a/app/views/static_pages/inquiry.html.erb
+++ b/app/views/static_pages/inquiry.html.erb
@@ -1,3 +1,3 @@
 <div class='container form-container'>
-  <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSdL6sC1LmCqvFG9LKk1jGM2KY-UXTroPqx83J9dcg-_rlxZWg/viewform?usp=header" width="100%" height="1077" frameborder="0" marginheight="0" marginwidth="0">読み込んでいます…</iframe>
+  <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSdL6sC1LmCqvFG9LKk1jGM2KY-UXTroPqx83J9dcg-_rlxZWg/viewform?embedded=true" width="100%" height="1077" frameborder="0" marginheight="0" marginwidth="0">読み込んでいます…</iframe>
 </div>


### PR DESCRIPTION
## 概要
- お問合せフォームの背景色が入り込まないよう、リンクをHTML埋め込みように修正しました。
