### PR TITLE
[Fix] #193 投稿詳細、投稿カードにユーザーのアバター画像を反映

### DIFF
--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -12,12 +12,20 @@
     <% if post.draft? %>
       <div class="badge badge-accent text-white">下書き</div>
     <% end %>
-    <p class="txt-limit"><%= post.description %></p>
-    <p><%= post.user.name %></p>
-    <div class="card-actions justify-end">
+    <div class="card-actions ">
       <% post.tags.each do |tag| %>
         <div class="badge badge-outline"><%= tag.name %></div>
       <% end %>
+    </div>
+
+    <p class="txt-limit"><%= post.description %></p>
+    <div class="flex items-center">
+      <div class="avatar mr-2">
+        <div class="w-16 rounded-full">
+          <%= image_tag "#{post.user.avatar}"%>
+        </div>
+      </div>
+      <%= post.user.name%>
     </div>
   </div>
 <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -36,7 +36,7 @@
       <%= link_to user_path(@post.user), class: "flex items-center text-lg underline underline-offset-4 hover:text-secondary hover:duration-100", data: { turbo: false } do %>
         <div class="avatar mr-2">
           <div class="w-16 rounded-full">
-            <%= image_tag "post_default.png"%>
+            <%= image_tag "#{@post.user.avatar}"%>
           </div>
         </div>
         <%= @post.user.name%>


### PR DESCRIPTION
## issue番号
#193 

## 概要
アバター画像を設定しているユーザーの投稿詳細で、アバター画像ではなくデフォルト画像が表示されていたため修正しました。
合わせて、投稿カードのデザイン修正も行いました。

## 実施内容
- 投稿詳細のアバター画像欄にデフォルト画像が表示されるようになっていたため、アバター画像の設定がある場合はそちらが表示されるよう修正しました。
- 投稿カードにもアバター画像またはデフォルト画像が表示されるよう記述を追加＆それに伴いタグの位置を修正しました。

## 備考
