### PR TITLE
[Fix] #195 ユーザーのレベルアップロジックの修正

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -38,7 +38,14 @@ class PostsController < ApplicationController
       if post.draft?
         redirect_to post_path(post), notice: t("defaults.flash_message.created", item: "下書き")
       else
-        current_user.update(level: current_user.level + 1) if current_user.posts.published.count % 5 == 0
+        # レベルアップ条件
+        if current_user.posts.published.count == 1 && current_user.max_post_count == 0 # 初めての投稿
+          current_user.update(max_post_count: 1) # 更新処理
+          current_user.update(level: current_user.level + 1)
+        elsif current_user.posts.published.count > current_user.max_post_count # 投稿公開数の最多更新
+          current_user.update(max_post_count: current_user.posts.published.count) # 更新処理
+          current_user.update(level: current_user.level + 1) if current_user.max_post_count % 3 == 0 # 3件投稿ごと
+        end
         redirect_to post_path(post), notice: t("defaults.flash_message.created", item: Post.model_name.human)
       end
     else
@@ -64,6 +71,14 @@ class PostsController < ApplicationController
       if post.draft?
         redirect_to post_path(post), notice: t("defaults.flash_message.draft_edited")
       else
+        # レベルアップ条件
+        if current_user.posts.published.count == 1 && current_user.max_post_count == 0 # 初めての投稿公開
+          current_user.update(max_post_count: 1) # 更新処理
+          current_user.update(level: current_user.level + 1)
+        elsif current_user.posts.published.count > current_user.max_post_count # 投稿公開数の最多更新
+          current_user.update(max_post_count: current_user.posts.published.count) # 更新処理
+          current_user.update(level: current_user.level + 1) if current_user.max_post_count % 3 == 0 # 3件投稿ごと
+        end
         redirect_to post_path(post), notice: t("defaults.flash_message.publish_edited", item: Post.model_name.human)
       end
     else

--- a/db/migrate/20250131013750_add_max_post_count_to_users.rb
+++ b/db/migrate/20250131013750_add_max_post_count_to_users.rb
@@ -1,0 +1,5 @@
+class AddMaxPostCountToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :max_post_count, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_09_015137) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_31_013750) do
   create_table "bookmarks", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "post_id", null: false
@@ -89,6 +89,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_09_015137) do
     t.string "provider"
     t.string "uid"
     t.integer "line_alert", default: 0, null: false
+    t.integer "max_post_count", default: 0, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
## issue番号
close #195 

## 概要
5件投稿ごとにユーザーがレベルアップする仕組みでしたが、投稿削除後に再度投稿するとレベルが上がってしまう実装だったため、ユーザーのレベルアップロジックを修正しました。
またこれまでの投稿数を鑑み、レベルアップ条件を「初めての投稿時」と「その後3件投稿ごとに」に変更しました。

## 実施内容

- Userモデルにmax_post_countを追加、デフォルト値は0
- レベルアップ条件（新規投稿、編集時）
  - 公開中の投稿総数 == 1 && max_post_count == 0の時(初めての投稿)
  - 公開中の投稿総数 > max_post_countかつ投稿総数 % 3 == 0の時(3件投稿ごとにレベル上昇)
## 備考
