### PR TITLE
[Fix] #197 OpenAI APIのモデルをgpt-4o-miniに変更

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,10 +10,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Install Heroku CLI
-        run: |
-          curl https://cli-assets.heroku.com/install.sh | sh
-
       - name: Deploy to Heroku
         uses: gonuit/heroku-docker-deploy@v1.3.3
         with:

--- a/app/services/openai/base_service.rb
+++ b/app/services/openai/base_service.rb
@@ -8,7 +8,7 @@ module Openai
   class BaseService
     attr_reader :model
 
-    def initialize(model: "gpt-3.5-turbo", timeout: 10)
+    def initialize(model: "gpt-4o-mini", timeout: 10)
       @model = model
       @connection = Faraday.new(url: "https://api.openai.com") do |f|
         f.headers["Authorization"] = "Bearer #{Rails.application.credentials.OPENAI_API_KEY}"


### PR DESCRIPTION
## issue番号
close #197 

## 概要
- OpenAI APIのモデルをgpt-4o-miniに変更しました
- Heroku自動デプロイエラーのissueが解決していたので、CI/CD用ファイルの変更を元に戻しました

## 実施内容


## 備考
https://github.com/heroku/cli/issues/3142